### PR TITLE
Implement a binary reader for function references instructions.

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -760,6 +760,14 @@ pub enum Instruction<'a> {
     F32x4RelaxedMax,
     F64x2RelaxedMin,
     F64x2RelaxedMax,
+
+    // Function references proposal. TODO(dhil): Merge with the above
+    // list.
+    CallRef,
+    ReturnCallRef,
+    RefAsNonNull,
+    BrOnNull(u32),
+    BrOnNonNull(u32),
 }
 
 impl Encode for Instruction<'_> {
@@ -2299,6 +2307,20 @@ impl Encode for Instruction<'_> {
             Instruction::F64x2RelaxedMax => {
                 sink.push(0xFD);
                 0xEEu32.encode(sink);
+            }
+
+            // Function references proposal. TODO(dhil): Merge with
+            // the above list.
+            Instruction::CallRef => sink.push(0x14),
+            Instruction::ReturnCallRef => sink.push(0x15),
+            Instruction::RefAsNonNull => sink.push(0xD3),
+            Instruction::BrOnNull(l) => {
+                sink.push(0xD4);
+                l.encode(sink);
+            }
+            Instruction::BrOnNonNull(l) => {
+                sink.push(0xD6);
+                l.encode(sink);
             }
         }
     }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -917,6 +917,14 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         | O::ReturnCall { .. }
         | O::ReturnCallIndirect { .. }
         | O::AtomicFence { .. } => return Err(Error::no_mutations_applicable()),
+
+        // Function references proposal instructions. TODO(dhil):
+        // Merge with the above list.
+        O::CallRef => I::CallRef,
+        O::ReturnCallRef => I::ReturnCallRef,
+        O::RefAsNonNull => I::RefAsNonNull,
+        O::BrOnNull { relative_depth } => I::BrOnNull(*relative_depth),
+        O::BrOnNonNull { relative_depth } => I::BrOnNonNull(*relative_depth),
     })
 }
 

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1884,6 +1884,19 @@ impl<'a> BinaryReader<'a> {
             0xfd => self.read_0xfd_operator()?,
             0xfe => self.read_0xfe_operator()?,
 
+            // Function references proposal operators. TODO(dhil): Put
+            // each into its appropriate place within the above list.
+
+            0x14 => Operator::CallRef,
+            0x15 => Operator::ReturnCallRef,
+            0xd3 => Operator::RefAsNonNull,
+            0xd4 => Operator::BrOnNull {
+                relative_depth: self.read_var_u32()?,
+            },
+            0xd6 => Operator::BrOnNonNull {
+                relative_depth: self.read_var_u32()?,
+            },
+
             _ => {
                 return Err(BinaryReaderError::new(
                     format!("illegal opcode: 0x{:x}", code),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1886,7 +1886,6 @@ impl<'a> BinaryReader<'a> {
 
             // Function references proposal operators. TODO(dhil): Put
             // each into its appropriate place within the above list.
-
             0x14 => Operator::CallRef,
             0x15 => Operator::ReturnCallRef,
             0xd3 => Operator::RefAsNonNull,

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -1012,11 +1012,11 @@ pub enum Operator<'a> {
     ReturnCallRef,
     RefAsNonNull,
     BrOnNull {
-        relative_depth: u32
+        relative_depth: u32,
     },
     BrOnNonNull {
-        relative_depth: u32
-    }
+        relative_depth: u32,
+    },
 }
 
 /// A reader for a core WebAssembly function's operators.

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -1005,6 +1005,18 @@ pub enum Operator<'a> {
     F32x4RelaxedMax,
     F64x2RelaxedMin,
     F64x2RelaxedMax,
+
+    // Function references proposal operators. TODO(dhil): Put into
+    // appropriate places in the above list.
+    CallRef,
+    ReturnCallRef,
+    RefAsNonNull,
+    BrOnNull {
+        relative_depth: u32
+    },
+    BrOnNonNull {
+        relative_depth: u32
+    }
 }
 
 /// A reader for a core WebAssembly function's operators.

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2079,11 +2079,12 @@ impl OperatorValidator {
             // Function references proposal operators. TODO(dhil): Put
             // each rule in its appropriate place within the above
             // list.
-            Operator::CallRef
-            | Operator::ReturnCallRef
-            | Operator::RefAsNonNull => todo!("implement static semantics for function references proposal instructions."),
-            Operator::BrOnNull { relative_depth }
-            | Operator::BrOnNonNull { relative_depth } => todo!("implement static semantics for function references proposal instructions.")
+            Operator::CallRef | Operator::ReturnCallRef | Operator::RefAsNonNull => {
+                todo!("implement static semantics for function references proposal instructions.")
+            }
+            Operator::BrOnNull { relative_depth } | Operator::BrOnNonNull { relative_depth } => {
+                todo!("implement static semantics for function references proposal instructions.")
+            }
         }
         Ok(())
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2075,6 +2075,15 @@ impl OperatorValidator {
                 self.pop_operand(Some(ty))?;
                 self.pop_operand(Some(ValType::I32))?;
             }
+
+            // Function references proposal operators. TODO(dhil): Put
+            // each rule in its appropriate place within the above
+            // list.
+            Operator::CallRef
+            | Operator::ReturnCallRef
+            | Operator::RefAsNonNull => todo!("implement static semantics for function references proposal instructions."),
+            Operator::BrOnNull { relative_depth }
+            | Operator::BrOnNonNull { relative_depth } => todo!("implement static semantics for function references proposal instructions.")
         }
         Ok(())
     }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2005,7 +2005,7 @@ impl Printer {
                     relative_depth,
                     label(*relative_depth),
                 )?;
-            },
+            }
             BrOnNonNull { relative_depth } => {
                 write!(
                     self.result,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1992,6 +1992,28 @@ impl Printer {
             F32x4RelaxedMax => self.result.push_str("f32x4.relaxed_max"),
             F64x2RelaxedMin => self.result.push_str("f64x2.relaxed_min"),
             F64x2RelaxedMax => self.result.push_str("f64x2.relaxed_max"),
+
+            // Function references proposal instructions. TODO(dhil):
+            // Merge with the above list.
+            CallRef => self.result.push_str("call_ref"),
+            ReturnCallRef => self.result.push_str("return_call_ref"),
+            RefAsNonNull => self.result.push_str("ref.as_non_null"),
+            BrOnNull { relative_depth } => {
+                write!(
+                    self.result,
+                    "br_on_null {} (;{};)",
+                    relative_depth,
+                    label(*relative_depth),
+                )?;
+            },
+            BrOnNonNull { relative_depth } => {
+                write!(
+                    self.result,
+                    "br_on_non_null {} (;{};)",
+                    relative_depth,
+                    label(*relative_depth),
+                )?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This patch extends the binary reader to enable reading of
    
* `call_ref`
* `return_call_ref`
* `ref.as_non_null`
* `br_on_null $l`
* `br_on_non_null $l`

The static semantics are yet to be implemented.

I have updated the patch to also include mutators and binary encoders for the above instructions.

(I have removed the latest commits from upstream/main to keep the PR clean.)