### PR TITLE
Static semantics for function references

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1530,7 +1530,7 @@ impl<'a> BinaryReader<'a> {
                 self.position += 1;
                 Ok(HeapType::Extern)
             }
-            x if 0xf0 & x == 0 => {
+            x if 0x80 & x == 0 => {
                 self.position += 1;
                 Ok(HeapType::Index(x as u32))
             }

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1571,10 +1571,10 @@ impl<'a> BinaryReader<'a> {
                 self.position += 1;
                 Some(ValType::Ref(EXTERN_REF))
             }
-            x @ (0x6C | 0x6D) => {
+            x @ (0x6B | 0x6C) => {
                 self.position += 1;
                 Some(ValType::Ref(RefType {
-                    nullable: x == 0x6D,
+                    nullable: x == 0x6C,
                     heap_type: self.read_heap_type()?,
                 }))
             }

--- a/crates/wasmparser/src/readers/core/code.rs
+++ b/crates/wasmparser/src/readers/core/code.rs
@@ -56,11 +56,13 @@ impl<'a> FunctionBody<'a> {
         reader
     }
 
+    // This seems not future proof and bug-prone.  Why do we skip over stuff we
+    // likely already parsed anyway?
     fn skip_locals(reader: &mut BinaryReader) -> Result<()> {
         let count = reader.read_var_u32()?;
         for _ in 0..count {
             reader.read_var_u32()?;
-            reader.read_var_u32()?;
+            reader.read_val_type()?;
         }
         Ok(())
     }

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-use crate::{FuncType, GlobalType, MemoryType, RefType, TableType, ValType};
+use crate::{
+    BinaryReaderError, FuncType, GlobalType, MemoryType, RefType, TableType, ValType, WasmFeatures,
+};
 use std::ops::Range;
 
 /// Types that qualify as Wasm function types for validation purposes.
@@ -215,6 +217,13 @@ pub trait WasmModuleResources {
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType>;
     /// Returns the element type at the given index.
     fn element_type_at(&self, at: u32) -> Option<RefType>;
+    /// Check a value type. This requires using func_type_at to check references
+    fn check_value_type(
+        &self,
+        t: ValType,
+        features: &WasmFeatures,
+        offset: usize,
+    ) -> Result<(), BinaryReaderError>;
 
     /// Returns the number of elements.
     fn element_count(&self) -> u32;
@@ -251,6 +260,14 @@ where
     }
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
+    }
+    fn check_value_type(
+        &self,
+        t: ValType,
+        features: &WasmFeatures,
+        offset: usize,
+    ) -> Result<(), BinaryReaderError> {
+        T::check_value_type(self, t, features, offset)
     }
     fn element_type_at(&self, at: u32) -> Option<RefType> {
         T::element_type_at(self, at)
@@ -299,6 +316,15 @@ where
 
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
+    }
+
+    fn check_value_type(
+        &self,
+        t: ValType,
+        features: &WasmFeatures,
+        offset: usize,
+    ) -> Result<(), BinaryReaderError> {
+        T::check_value_type(self, t, features, offset)
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -208,6 +208,9 @@ pub trait WasmModuleResources {
     fn global_at(&self, at: u32) -> Option<GlobalType>;
     /// Returns the `FuncType` associated with the given type index.
     fn func_type_at(&self, type_idx: u32) -> Option<&Self::FuncType>;
+    /// Returns the type index associated with the given function
+    /// index. type_of_function = func_type_at(type_index_of_function)
+    fn type_index_of_function(&self, func_idx: u32) -> Option<u32>;
     /// Returns the `FuncType` associated with the given function index.
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType>;
     /// Returns the element type at the given index.
@@ -242,6 +245,9 @@ where
     }
     fn func_type_at(&self, at: u32) -> Option<&Self::FuncType> {
         T::func_type_at(self, at)
+    }
+    fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
+        T::type_index_of_function(self, func_idx)
     }
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
@@ -285,6 +291,10 @@ where
 
     fn func_type_at(&self, type_idx: u32) -> Option<&Self::FuncType> {
         T::func_type_at(self, type_idx)
+    }
+
+    fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
+        T::type_index_of_function(self, func_idx)
     }
 
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -244,6 +244,10 @@ pub struct WasmFeatures {
 }
 
 impl WasmFeatures {
+    /// NOTE: This only checks that the value type corresponds to the feature set!!
+    ///
+    /// To check that reference types are valid, we need access to the module
+    /// types. Use module.check_value_type.
     pub(crate) fn check_value_type(&self, ty: ValType) -> Result<(), &'static str> {
         match ty {
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => Ok(()),

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -603,8 +603,11 @@ impl Validator {
                 state.module.assert_mut().tables.reserve(count as usize);
                 Ok(())
             },
-            |state, features, _, ty, offset| {
-                state.module.assert_mut().add_table(ty, features, offset)
+            |state, features, types, ty, offset| {
+                state
+                    .module
+                    .assert_mut()
+                    .add_table(ty, features, types, offset)
             },
         )
     }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -13,13 +13,6 @@ use crate::{
 use indexmap::IndexMap;
 use std::{collections::HashSet, sync::Arc};
 
-fn check_value_type(ty: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
-    match features.check_value_type(ty) {
-        Ok(()) => Ok(()),
-        Err(e) => Err(BinaryReaderError::new(e, offset)),
-    }
-}
-
 // Section order for WebAssembly modules.
 //
 // Component sections are unordered and allow for duplicates,
@@ -135,7 +128,7 @@ impl ModuleState {
         offset: usize,
     ) -> Result<()> {
         self.module
-            .check_global_type(&global.ty, features, offset)?;
+            .check_global_type(&global.ty, features, types, offset)?;
         self.check_init_expr(
             &global.init_expr,
             global.ty.content_type,
@@ -173,6 +166,7 @@ impl ModuleState {
         types: &TypeList,
         offset: usize,
     ) -> Result<()> {
+        self.module.check_ref_type(e.ty, types, offset)?;
         let RefType {
             nullable,
             heap_type,
@@ -189,14 +183,7 @@ impl ModuleState {
                     }
                 }
             }
-            HeapType::Func => {}
-            HeapType::Extern if features.reference_types => {}
-            HeapType::Extern => {
-                return Err(BinaryReaderError::new(
-                    "reference types must be enabled for externref elem segment",
-                    offset,
-                ))
-            }
+            HeapType::Func | HeapType::Extern => {}
         }
         match e.kind {
             ElementKind::Active {
@@ -393,7 +380,7 @@ impl Module {
         let ty = match ty {
             crate::Type::Func(t) => {
                 for ty in t.params.iter().chain(t.returns.iter()) {
-                    check_value_type(*ty, features, offset)?;
+                    self.check_value_type(*ty, features, types, offset)?;
                 }
                 if t.returns.len() > 1 && !features.multi_value {
                     return Err(BinaryReaderError::new(
@@ -593,7 +580,7 @@ impl Module {
                 EntityType::Tag(self.types[t.func_type_idx as usize])
             }
             TypeRef::Global(t) => {
-                self.check_global_type(t, features, offset)?;
+                self.check_global_type(t, features, types, offset)?;
                 EntityType::Global(*t)
             }
         })
@@ -614,7 +601,7 @@ impl Module {
             }
             HeapType::Index(_) => {
                 return Err(BinaryReaderError::new(
-                    "it doesn't make sense for a table type to be an index",
+                    "unknown type: table types cannot be index",
                     offset,
                 ))
             }
@@ -699,6 +686,40 @@ impl Module {
         }).collect::<Result<_>>()
     }
 
+    fn check_value_type(
+        &self,
+        ty: ValType,
+        features: &WasmFeatures,
+        types: &TypeList,
+        offset: usize,
+    ) -> Result<()> {
+        match features.check_value_type(ty) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(BinaryReaderError::new(e, offset)),
+        }?;
+        // The above only checks the value type for features.
+        // We must check it if it's a reference.
+        match ty {
+            ValType::Ref(rt) => {
+                self.check_ref_type(rt, types, offset)?;
+            }
+            _ => (),
+        }
+        Ok(())
+    }
+
+    fn check_ref_type(&self, ty: RefType, types: &TypeList, offset: usize) -> Result<()> {
+        // Check that the heap type is valid
+        match ty.heap_type {
+            HeapType::Func | HeapType::Extern => (),
+            HeapType::Index(type_index) => {
+                // Just check that the index is valid
+                self.func_type_at(type_index, types, offset)?;
+            }
+        }
+        Ok(())
+    }
+
     fn check_tag_type(
         &self,
         ty: &TagType,
@@ -726,9 +747,10 @@ impl Module {
         &self,
         ty: &GlobalType,
         features: &WasmFeatures,
+        types: &TypeList,
         offset: usize,
     ) -> Result<()> {
-        check_value_type(ty.content_type, features, offset)
+        self.check_value_type(ty.content_type, features, types, offset)
     }
 
     fn check_limits<T>(&self, initial: T, maximum: Option<T>, offset: usize) -> Result<()>
@@ -919,6 +941,11 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
         self.func_type_at(self.type_index_of_function(at)?)
     }
 
+    fn check_value_type(&self, t: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
+        self.module
+            .check_value_type(t, features, self.types, offset)
+    }
+
     fn element_type_at(&self, at: u32) -> Option<RefType> {
         self.module.element_types.get(at as usize).cloned()
     }
@@ -977,6 +1004,11 @@ impl WasmModuleResources for ValidatorResources {
 
     fn type_of_function(&self, at: u32) -> Option<&Self::FuncType> {
         self.func_type_at(self.type_index_of_function(at)?)
+    }
+
+    fn check_value_type(&self, t: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
+        self.0
+            .check_value_type(t, features, self.0.snapshot.as_ref().unwrap(), offset)
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -911,8 +911,12 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
         )
     }
 
+    fn type_index_of_function(&self, at: u32) -> Option<u32> {
+        self.module.functions.get(at as usize).cloned()
+    }
+
     fn type_of_function(&self, at: u32) -> Option<&Self::FuncType> {
-        self.func_type_at(*self.module.functions.get(at as usize)?)
+        self.func_type_at(self.type_index_of_function(at)?)
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {
@@ -967,8 +971,12 @@ impl WasmModuleResources for ValidatorResources {
         )
     }
 
+    fn type_index_of_function(&self, at: u32) -> Option<u32> {
+        self.0.functions.get(at as usize).cloned()
+    }
+
     fn type_of_function(&self, at: u32) -> Option<&Self::FuncType> {
-        self.func_type_at(*self.0.functions.get(at as usize)?)
+        self.func_type_at(self.type_index_of_function(at)?)
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -173,14 +173,12 @@ impl ModuleState {
         } = e.ty;
         match heap_type {
             HeapType::Index(_) => {
-                if nullable { /* "as long as the index is ok" */
-                } else {
-                    if !e.items.get_items_reader()?.get_count() > 0 {
-                        return Err(BinaryReaderError::new(
-                            "a non-nullable element must come with an initialization expression",
-                            offset,
-                        ));
-                    }
+                // nullable: "as long as the index is ok"
+                if !nullable && e.items.get_items_reader()?.get_count() <= 0 {
+                    return Err(BinaryReaderError::new(
+                        "a non-nullable element must come with an initialization expression",
+                        offset,
+                    ));
                 }
             }
             HeapType::Func | HeapType::Extern => {}
@@ -191,6 +189,7 @@ impl ModuleState {
                 init_expr,
             } => {
                 let table = self.module.table_at(table_index, offset)?;
+                // This should be updated to matches(...) but Daniel has lock
                 if e.ty != table.element_type {
                     return Err(BinaryReaderError::new(
                         format!(

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -80,7 +80,8 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     /// This should be used if the application is already reading local
     /// definitions and there's no need to re-parse the function again.
     pub fn define_locals(&mut self, offset: usize, count: u32, ty: ValType) -> Result<()> {
-        self.validator.define_locals(offset, count, ty)
+        self.validator
+            .define_locals(offset, count, ty, &self.resources)
     }
 
     /// Validates the next operator in a function.

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -1443,12 +1443,12 @@ impl OperatorValidator {
             }
             Operator::RefIsNull => {
                 self.check_reference_types_enabled()?;
-                match self.pop_operand(None, resources)? {
-                    None | Some(ValType::Ref(RefType { nullable: true, .. })) => {}
-                    _ => {
-                        return Err(OperatorValidatorError::new(
-                            "type mismatch: invalid reference type in ref.is_null",
-                        ))
+                match self.pop_ref(resources)? {
+                    None => {}
+                    Some(RefType { nullable, .. }) => {
+                        if !nullable {
+                            self.check_function_references_enabled()?;
+                        }
                     }
                 }
                 self.push_operand(ValType::I32)?;

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -442,6 +442,15 @@ impl OperatorValidator {
         Ok(())
     }
 
+    fn check_function_references_enabled(&self) -> OperatorValidatorResult<()> {
+        if !self.features.function_references {
+            return Err(OperatorValidatorError::new(
+                "function references support is not enabled",
+            ));
+        }
+        Ok(())
+    }
+
     fn check_simd_enabled(&self) -> OperatorValidatorResult<()> {
         if !self.features.simd {
             return Err(OperatorValidatorError::new("SIMD support is not enabled"));
@@ -2105,6 +2114,7 @@ impl OperatorValidator {
             // each rule in its appropriate place within the above
             // list.
             Operator::CallRef => {
+                self.check_function_references_enabled()?;
                 if let Some(rt) = self.pop_ref(resources)? {
                     match rt.heap_type {
                         HeapType::Index(type_index) => {
@@ -2127,6 +2137,7 @@ impl OperatorValidator {
                 }
             }
             Operator::RefAsNonNull => {
+                self.check_function_references_enabled()?;
                 if let Some(RefType { heap_type, .. }) = self.pop_ref(resources)? {
                     match heap_type {
                         HeapType::Func | HeapType::Extern => (),

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -180,6 +180,19 @@ impl OperatorValidator {
         resources: &impl WasmModuleResources,
     ) -> Result<()> {
         resources.check_value_type(ty, &self.features, offset)?;
+        // As far as i can tell, this isn't specified in the spec for function
+        // references, it's only tested and mentioned in the overview
+        match ty {
+            ValType::Ref(RefType {
+                nullable: false, ..
+            }) => {
+                return Err(BinaryReaderError::new(
+                    format!("non-defaultable local type: {}", ty_to_str(ty)),
+                    offset,
+                ))
+            }
+            _ => (),
+        }
         if count == 0 {
             return Ok(());
         }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -1446,19 +1446,22 @@ impl OperatorValidator {
             }
             Operator::RefFunc { function_index } => {
                 self.check_reference_types_enabled()?;
-                if resources.type_of_function(function_index).is_none() {
-                    return Err(OperatorValidatorError::new(format!(
-                        "unknown function {}: function index out of bounds",
-                        function_index,
-                    )));
-                }
+                let type_index =
+                    if let Some(type_index) = resources.type_index_of_function(function_index) {
+                        type_index
+                    } else {
+                        return Err(OperatorValidatorError::new(format!(
+                            "unknown function {}: function index out of bounds",
+                            function_index,
+                        )));
+                    };
                 if !resources.is_function_referenced(function_index) {
                     return Err(OperatorValidatorError::new("undeclared function reference"));
                 }
                 if self.features.function_references {
                     self.push_operand(ValType::Ref(RefType {
                         nullable: false,
-                        heap_type: HeapType::Index(function_index),
+                        heap_type: HeapType::Index(type_index),
                     }))?;
                 } else {
                     self.push_operand(ValType::Ref(FUNC_REF))?;

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2126,7 +2126,22 @@ impl OperatorValidator {
                     }
                 }
             }
-            Operator::ReturnCallRef | Operator::RefAsNonNull => {
+            Operator::RefAsNonNull => {
+                if let Some(RefType { heap_type, .. }) = self.pop_ref(resources)? {
+                    match heap_type {
+                        HeapType::Func | HeapType::Extern => (),
+                        HeapType::Index(type_index) => {
+                            // Just check that the index is valid
+                            func_type_at(resources, type_index)?;
+                        }
+                    }
+                    self.push_operand(ValType::Ref(RefType {
+                        nullable: false,
+                        heap_type,
+                    }))?;
+                }
+            }
+            Operator::ReturnCallRef => {
                 bail_op_err!(
                     "implement static semantics for function references proposal instructions."
                 )

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -172,10 +172,14 @@ impl OperatorValidator {
         }
     }
 
-    pub fn define_locals(&mut self, offset: usize, count: u32, ty: ValType) -> Result<()> {
-        self.features
-            .check_value_type(ty)
-            .map_err(|e| BinaryReaderError::new(e, offset))?;
+    pub fn define_locals(
+        &mut self,
+        offset: usize,
+        count: u32,
+        ty: ValType,
+        resources: &impl WasmModuleResources,
+    ) -> Result<()> {
+        resources.check_value_type(ty, &self.features, offset)?;
         if count == 0 {
             return Ok(());
         }
@@ -216,10 +220,14 @@ impl OperatorValidator {
     /// This is used by instructions to represent a value that is pushed to the
     /// operand stack. This can fail, but only if `Type` is feature gated.
     /// Otherwise the push operation always succeeds.
-    fn push_operand(&mut self, ty: ValType) -> OperatorValidatorResult<()> {
-        self.features
-            .check_value_type(ty)
-            .map_err(OperatorValidatorError::new)?;
+    fn push_operand(
+        &mut self,
+        ty: ValType,
+        resources: &impl WasmModuleResources,
+    ) -> OperatorValidatorResult<()> {
+        resources
+            .check_value_type(ty, &self.features, 0)
+            .map_err(|t| OperatorValidatorError::new(t.inner.message))?;
         self.operands.push(Some(ty));
         Ok(())
     }
@@ -321,7 +329,7 @@ impl OperatorValidator {
         // All of the parameters are now also available in this control frame,
         // so we push them here in order.
         for ty in params(ty, resources)? {
-            self.push_operand(ty)?;
+            self.push_operand(ty, resources)?;
         }
         Ok(())
     }
@@ -525,13 +533,10 @@ impl OperatorValidator {
         resources: impl WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
         match ty {
-            BlockType::Empty
-            | BlockType::Type(ValType::I32)
-            | BlockType::Type(ValType::I64)
-            | BlockType::Type(ValType::F32)
-            | BlockType::Type(ValType::F64) => Ok(()),
-            BlockType::Type(ValType::Ref(_)) => self.check_reference_types_enabled(),
-            BlockType::Type(ValType::V128) => self.check_simd_enabled(),
+            BlockType::Empty => Ok(()),
+            BlockType::Type(t) => resources
+                .check_value_type(t, &self.features, 0)
+                .map_err(|t| OperatorValidatorError::new(t.inner.message)),
             BlockType::FuncType(idx) => {
                 if !self.features.multi_value {
                     return Err(OperatorValidatorError::new(
@@ -565,7 +570,7 @@ impl OperatorValidator {
             self.pop_operand(Some(ty), resources)?;
         }
         for ty in ty.outputs() {
-            self.push_operand(ty)?;
+            self.push_operand(ty, resources)?;
         }
         Ok(())
     }
@@ -597,7 +602,7 @@ impl OperatorValidator {
             self.pop_operand(Some(ty), resources)?;
         }
         for ty in ty.outputs() {
-            self.push_operand(ty)?;
+            self.push_operand(ty, resources)?;
         }
         Ok(())
     }
@@ -683,7 +688,7 @@ impl OperatorValidator {
                 // Push exception argument types.
                 let ty = tag_at(&resources, index)?;
                 for ty in ty.inputs() {
-                    self.push_operand(ty)?;
+                    self.push_operand(ty, resources)?;
                 }
             }
             Operator::Throw { index } => {
@@ -718,7 +723,7 @@ impl OperatorValidator {
                 // depth for validity
                 let _ = self.jump(relative_depth)?;
                 for ty in results(frame.block_type, resources)? {
-                    self.push_operand(ty)?;
+                    self.push_operand(ty, resources)?;
                 }
             }
             Operator::CatchAll => {
@@ -748,7 +753,7 @@ impl OperatorValidator {
                     frame = self.pop_ctrl(resources)?;
                 }
                 for ty in results(frame.block_type, resources)? {
-                    self.push_operand(ty)?;
+                    self.push_operand(ty, resources)?;
                 }
             }
             Operator::Br { relative_depth } => {
@@ -765,7 +770,7 @@ impl OperatorValidator {
                     self.pop_operand(Some(ty), resources)?;
                 }
                 for ty in label_types(ty, resources, kind)? {
-                    self.push_operand(ty)?;
+                    self.push_operand(ty, resources)?;
                 }
             }
             Operator::BrTable { ref table } => {
@@ -858,11 +863,11 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ty), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ty)?;
+                self.push_operand(ty, resources)?;
             }
             Operator::LocalGet { local_index } => {
                 let ty = self.local(local_index)?;
-                self.push_operand(ty)?;
+                self.push_operand(ty, resources)?;
             }
             Operator::LocalSet { local_index } => {
                 let ty = self.local(local_index)?;
@@ -871,11 +876,11 @@ impl OperatorValidator {
             Operator::LocalTee { local_index } => {
                 let ty = self.local(local_index)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ty)?;
+                self.push_operand(ty, resources)?;
             }
             Operator::GlobalGet { global_index } => {
                 if let Some(ty) = resources.global_at(global_index) {
-                    self.push_operand(ty.content_type)?;
+                    self.push_operand(ty.content_type, resources)?;
                 } else {
                     return Err(OperatorValidatorError::new(
                         "unknown global: global index out of bounds",
@@ -899,49 +904,49 @@ impl OperatorValidator {
             Operator::I32Load { memarg } => {
                 let ty = self.check_memarg(memarg, 2, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64Load { memarg } => {
                 let ty = self.check_memarg(memarg, 3, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::F32Load { memarg } => {
                 self.check_non_deterministic_enabled()?;
                 let ty = self.check_memarg(memarg, 2, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F64Load { memarg } => {
                 self.check_non_deterministic_enabled()?;
                 let ty = self.check_memarg(memarg, 3, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::I32Load8S { memarg } | Operator::I32Load8U { memarg } => {
                 let ty = self.check_memarg(memarg, 0, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32Load16S { memarg } | Operator::I32Load16U { memarg } => {
                 let ty = self.check_memarg(memarg, 1, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64Load8S { memarg } | Operator::I64Load8U { memarg } => {
                 let ty = self.check_memarg(memarg, 0, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64Load16S { memarg } | Operator::I64Load16U { memarg } => {
                 let ty = self.check_memarg(memarg, 1, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64Load32S { memarg } | Operator::I64Load32U { memarg } => {
                 let ty = self.check_memarg(memarg, 2, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I32Store { memarg } => {
                 let ty = self.check_memarg(memarg, 2, resources)?;
@@ -997,7 +1002,7 @@ impl OperatorValidator {
                     ));
                 }
                 let index_ty = self.check_memory_index(mem, resources)?;
-                self.push_operand(index_ty)?;
+                self.push_operand(index_ty, resources)?;
             }
             Operator::MemoryGrow { mem, mem_byte } => {
                 if mem_byte != 0 && !self.features.multi_memory {
@@ -1007,21 +1012,21 @@ impl OperatorValidator {
                 }
                 let index_ty = self.check_memory_index(mem, resources)?;
                 self.pop_operand(Some(index_ty), resources)?;
-                self.push_operand(index_ty)?;
+                self.push_operand(index_ty, resources)?;
             }
-            Operator::I32Const { .. } => self.push_operand(ValType::I32)?,
-            Operator::I64Const { .. } => self.push_operand(ValType::I64)?,
+            Operator::I32Const { .. } => self.push_operand(ValType::I32, resources)?,
+            Operator::I64Const { .. } => self.push_operand(ValType::I64, resources)?,
             Operator::F32Const { .. } => {
                 self.check_non_deterministic_enabled()?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F64Const { .. } => {
                 self.check_non_deterministic_enabled()?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::I32Eqz => {
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32Eq
             | Operator::I32Ne
@@ -1035,11 +1040,11 @@ impl OperatorValidator {
             | Operator::I32GeU => {
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64Eqz => {
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64Eq
             | Operator::I64Ne
@@ -1053,7 +1058,7 @@ impl OperatorValidator {
             | Operator::I64GeU => {
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::F32Eq
             | Operator::F32Ne
@@ -1064,7 +1069,7 @@ impl OperatorValidator {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F32), resources)?;
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::F64Eq
             | Operator::F64Ne
@@ -1075,11 +1080,11 @@ impl OperatorValidator {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F64), resources)?;
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32Clz | Operator::I32Ctz | Operator::I32Popcnt => {
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32Add
             | Operator::I32Sub
@@ -1098,11 +1103,11 @@ impl OperatorValidator {
             | Operator::I32Rotr => {
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64Clz | Operator::I64Ctz | Operator::I64Popcnt => {
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64Add
             | Operator::I64Sub
@@ -1121,7 +1126,7 @@ impl OperatorValidator {
             | Operator::I64Rotr => {
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::F32Abs
             | Operator::F32Neg
@@ -1132,7 +1137,7 @@ impl OperatorValidator {
             | Operator::F32Sqrt => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F32Add
             | Operator::F32Sub
@@ -1144,7 +1149,7 @@ impl OperatorValidator {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F32), resources)?;
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F64Abs
             | Operator::F64Neg
@@ -1155,7 +1160,7 @@ impl OperatorValidator {
             | Operator::F64Sqrt => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::F64Add
             | Operator::F64Sub
@@ -1167,79 +1172,79 @@ impl OperatorValidator {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F64), resources)?;
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::I32WrapI64 => {
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32TruncF32S | Operator::I32TruncF32U => {
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32TruncF64S | Operator::I32TruncF64U => {
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64ExtendI32S | Operator::I64ExtendI32U => {
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64TruncF32S | Operator::I64TruncF32U => {
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64TruncF64S | Operator::I64TruncF64U => {
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::F32ConvertI32S | Operator::F32ConvertI32U => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F32ConvertI64S | Operator::F32ConvertI64U => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F32DemoteF64 => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F64ConvertI32S | Operator::F64ConvertI32U => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::F64ConvertI64S | Operator::F64ConvertI64U => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::F64PromoteF32 => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::I32ReinterpretF32 => {
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64ReinterpretF64 => {
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::F32ReinterpretI32 => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F64ReinterpretI64 => {
                 self.check_non_deterministic_enabled()?;
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::I32TruncSatF32S | Operator::I32TruncSatF32U => {
                 if !self.features.saturating_float_to_int {
@@ -1248,7 +1253,7 @@ impl OperatorValidator {
                     ));
                 }
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32TruncSatF64S | Operator::I32TruncSatF64U => {
                 if !self.features.saturating_float_to_int {
@@ -1257,7 +1262,7 @@ impl OperatorValidator {
                     ));
                 }
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64TruncSatF32S | Operator::I64TruncSatF32U => {
                 if !self.features.saturating_float_to_int {
@@ -1266,7 +1271,7 @@ impl OperatorValidator {
                     ));
                 }
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64TruncSatF64S | Operator::I64TruncSatF64U => {
                 if !self.features.saturating_float_to_int {
@@ -1275,7 +1280,7 @@ impl OperatorValidator {
                     ));
                 }
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I32Extend16S | Operator::I32Extend8S => {
                 if !self.features.sign_extension {
@@ -1284,7 +1289,7 @@ impl OperatorValidator {
                     ));
                 }
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
 
             Operator::I64Extend32S | Operator::I64Extend16S | Operator::I64Extend8S => {
@@ -1294,7 +1299,7 @@ impl OperatorValidator {
                     ));
                 }
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
 
             Operator::I32AtomicLoad { memarg }
@@ -1303,7 +1308,7 @@ impl OperatorValidator {
                 self.check_threads_enabled()?;
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64AtomicLoad { memarg }
             | Operator::I64AtomicLoad32U { memarg }
@@ -1312,7 +1317,7 @@ impl OperatorValidator {
                 self.check_threads_enabled()?;
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I32AtomicStore { memarg }
             | Operator::I32AtomicStore16 { memarg }
@@ -1350,7 +1355,7 @@ impl OperatorValidator {
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64AtomicRmwAdd { memarg }
             | Operator::I64AtomicRmwSub { memarg }
@@ -1376,7 +1381,7 @@ impl OperatorValidator {
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I32AtomicRmwXchg { memarg }
             | Operator::I32AtomicRmw16XchgU { memarg }
@@ -1385,7 +1390,7 @@ impl OperatorValidator {
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32AtomicRmwCmpxchg { memarg }
             | Operator::I32AtomicRmw16CmpxchgU { memarg }
@@ -1395,7 +1400,7 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I64AtomicRmwXchg { memarg }
             | Operator::I64AtomicRmw32XchgU { memarg }
@@ -1405,7 +1410,7 @@ impl OperatorValidator {
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64AtomicRmwCmpxchg { memarg }
             | Operator::I64AtomicRmw32CmpxchgU { memarg }
@@ -1416,14 +1421,14 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::MemoryAtomicNotify { memarg } => {
                 self.check_threads_enabled()?;
                 let ty = self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::MemoryAtomicWait32 { memarg } => {
                 self.check_threads_enabled()?;
@@ -1431,7 +1436,7 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::MemoryAtomicWait64 { memarg } => {
                 self.check_threads_enabled()?;
@@ -1439,7 +1444,7 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::AtomicFence { ref flags } => {
                 self.check_threads_enabled()?;
@@ -1451,10 +1456,13 @@ impl OperatorValidator {
             }
             Operator::RefNull { ty } => {
                 self.check_reference_types_enabled()?;
-                self.push_operand(ValType::Ref(RefType {
-                    nullable: true,
-                    heap_type: ty,
-                }))?;
+                self.push_operand(
+                    ValType::Ref(RefType {
+                        nullable: true,
+                        heap_type: ty,
+                    }),
+                    resources,
+                )?;
             }
             Operator::RefIsNull => {
                 self.check_reference_types_enabled()?;
@@ -1466,7 +1474,7 @@ impl OperatorValidator {
                         }
                     }
                 }
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::RefFunc { function_index } => {
                 self.check_reference_types_enabled()?;
@@ -1483,19 +1491,22 @@ impl OperatorValidator {
                     return Err(OperatorValidatorError::new("undeclared function reference"));
                 }
                 if self.features.function_references {
-                    self.push_operand(ValType::Ref(RefType {
-                        nullable: false,
-                        heap_type: HeapType::Index(type_index),
-                    }))?;
+                    self.push_operand(
+                        ValType::Ref(RefType {
+                            nullable: false,
+                            heap_type: HeapType::Index(type_index),
+                        }),
+                        resources,
+                    )?;
                 } else {
-                    self.push_operand(ValType::Ref(FUNC_REF))?;
+                    self.push_operand(ValType::Ref(FUNC_REF), resources)?;
                 }
             }
             Operator::V128Load { memarg } => {
                 self.check_simd_enabled()?;
                 let ty = self.check_memarg(memarg, 4, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Store { memarg } => {
                 self.check_simd_enabled()?;
@@ -1505,88 +1516,88 @@ impl OperatorValidator {
             }
             Operator::V128Const { .. } => {
                 self.check_simd_enabled()?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I8x16Splat | Operator::I16x8Splat | Operator::I32x4Splat => {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I64x2Splat => {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::I64), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F32x4Splat => {
                 self.check_non_deterministic_enabled()?;
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::F32), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F64x2Splat => {
                 self.check_non_deterministic_enabled()?;
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::F64), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I8x16ExtractLaneS { lane } | Operator::I8x16ExtractLaneU { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 16)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I16x8ExtractLaneS { lane } | Operator::I16x8ExtractLaneU { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 8)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I32x4ExtractLane { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 4)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I8x16ReplaceLane { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 16)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I16x8ReplaceLane { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 8)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I32x4ReplaceLane { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 4)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I64x2ExtractLane { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 2)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::I64)?;
+                self.push_operand(ValType::I64, resources)?;
             }
             Operator::I64x2ReplaceLane { lane } => {
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 2)?;
                 self.pop_operand(Some(ValType::I64), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F32x4ExtractLane { lane } => {
                 self.check_non_deterministic_enabled()?;
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 4)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::F32)?;
+                self.push_operand(ValType::F32, resources)?;
             }
             Operator::F32x4ReplaceLane { lane } => {
                 self.check_non_deterministic_enabled()?;
@@ -1594,14 +1605,14 @@ impl OperatorValidator {
                 self.check_simd_lane_index(lane, 4)?;
                 self.pop_operand(Some(ValType::F32), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F64x2ExtractLane { lane } => {
                 self.check_non_deterministic_enabled()?;
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 2)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::F64)?;
+                self.push_operand(ValType::F64, resources)?;
             }
             Operator::F64x2ReplaceLane { lane } => {
                 self.check_non_deterministic_enabled()?;
@@ -1609,7 +1620,7 @@ impl OperatorValidator {
                 self.check_simd_lane_index(lane, 2)?;
                 self.pop_operand(Some(ValType::F64), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F32x4Eq
             | Operator::F32x4Ne
@@ -1643,7 +1654,7 @@ impl OperatorValidator {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F32x4RelaxedMin
             | Operator::F32x4RelaxedMax
@@ -1652,7 +1663,7 @@ impl OperatorValidator {
                 self.check_relaxed_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I8x16Eq
             | Operator::I8x16Ne
@@ -1748,7 +1759,7 @@ impl OperatorValidator {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F32x4Ceil
             | Operator::F32x4Floor
@@ -1777,7 +1788,7 @@ impl OperatorValidator {
                 self.check_non_deterministic_enabled()?;
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Not
             | Operator::I8x16Abs
@@ -1807,7 +1818,7 @@ impl OperatorValidator {
             | Operator::I32x4ExtAddPairwiseI16x8U => {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I32x4RelaxedTruncSatF32x4S
             | Operator::I32x4RelaxedTruncSatF32x4U
@@ -1815,14 +1826,14 @@ impl OperatorValidator {
             | Operator::I32x4RelaxedTruncSatF64x2UZero => {
                 self.check_relaxed_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Bitselect => {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::F32x4Fma
             | Operator::F32x4Fms
@@ -1836,7 +1847,7 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128AnyTrue
             | Operator::I8x16AllTrue
@@ -1849,7 +1860,7 @@ impl OperatorValidator {
             | Operator::I64x2Bitmask => {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::I8x16Shl
             | Operator::I8x16ShrS
@@ -1866,19 +1877,19 @@ impl OperatorValidator {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I8x16Swizzle => {
                 self.check_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I8x16RelaxedSwizzle => {
                 self.check_relaxed_simd_enabled()?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::I8x16Shuffle { ref lanes } => {
                 self.check_simd_enabled()?;
@@ -1887,25 +1898,25 @@ impl OperatorValidator {
                 for i in lanes {
                     self.check_simd_lane_index(*i, 32)?;
                 }
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load8Splat { memarg } => {
                 self.check_simd_enabled()?;
                 let ty = self.check_memarg(memarg, 0, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load16Splat { memarg } => {
                 self.check_simd_enabled()?;
                 let ty = self.check_memarg(memarg, 1, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load32Splat { memarg } | Operator::V128Load32Zero { memarg } => {
                 self.check_simd_enabled()?;
                 let ty = self.check_memarg(memarg, 2, resources)?;
                 self.pop_operand(Some(ty), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load64Splat { memarg }
             | Operator::V128Load64Zero { memarg }
@@ -1918,7 +1929,7 @@ impl OperatorValidator {
                 self.check_simd_enabled()?;
                 let idx = self.check_memarg(memarg, 3, resources)?;
                 self.pop_operand(Some(idx), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load8Lane { memarg, lane } => {
                 self.check_simd_enabled()?;
@@ -1926,7 +1937,7 @@ impl OperatorValidator {
                 self.check_simd_lane_index(lane, 16)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(idx), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load16Lane { memarg, lane } => {
                 self.check_simd_enabled()?;
@@ -1934,7 +1945,7 @@ impl OperatorValidator {
                 self.check_simd_lane_index(lane, 8)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(idx), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load32Lane { memarg, lane } => {
                 self.check_simd_enabled()?;
@@ -1942,7 +1953,7 @@ impl OperatorValidator {
                 self.check_simd_lane_index(lane, 4)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(idx), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Load64Lane { memarg, lane } => {
                 self.check_simd_enabled()?;
@@ -1950,7 +1961,7 @@ impl OperatorValidator {
                 self.check_simd_lane_index(lane, 2)?;
                 self.pop_operand(Some(ValType::V128), resources)?;
                 self.pop_operand(Some(idx), resources)?;
-                self.push_operand(ValType::V128)?;
+                self.push_operand(ValType::V128, resources)?;
             }
             Operator::V128Store8Lane { memarg, lane } => {
                 self.check_simd_enabled()?;
@@ -2086,7 +2097,7 @@ impl OperatorValidator {
                     None => return Err(OperatorValidatorError::new("table index out of bounds")),
                 };
                 self.pop_operand(Some(ValType::I32), resources)?;
-                self.push_operand(ValType::Ref(ty))?;
+                self.push_operand(ValType::Ref(ty), resources)?;
             }
             Operator::TableSet { table } => {
                 self.check_reference_types_enabled()?;
@@ -2105,14 +2116,14 @@ impl OperatorValidator {
                 };
                 self.pop_operand(Some(ValType::I32), resources)?;
                 self.pop_operand(Some(ValType::Ref(ty)), resources)?;
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::TableSize { table } => {
                 self.check_reference_types_enabled()?;
                 if resources.table_at(table).is_none() {
                     return Err(OperatorValidatorError::new("table index out of bounds"));
                 }
-                self.push_operand(ValType::I32)?;
+                self.push_operand(ValType::I32, resources)?;
             }
             Operator::TableFill { table } => {
                 self.check_bulk_memory_enabled()?;
@@ -2138,7 +2149,7 @@ impl OperatorValidator {
                                 self.pop_operand(Some(ty), resources)?;
                             }
                             for ty in ty.outputs() {
-                                self.push_operand(ty)?;
+                                self.push_operand(ty, resources)?;
                             }
                         }
                         _ => {
@@ -2155,10 +2166,13 @@ impl OperatorValidator {
                 self.check_function_references_enabled()?;
                 if let Some(RefType { heap_type, .. }) = self.pop_ref(resources)? {
                     self.check_heap_type(heap_type, resources)?;
-                    self.push_operand(ValType::Ref(RefType {
-                        nullable: false,
-                        heap_type,
-                    }))?;
+                    self.push_operand(
+                        ValType::Ref(RefType {
+                            nullable: false,
+                            heap_type,
+                        }),
+                        resources,
+                    )?;
                 }
             }
             Operator::BrOnNull { relative_depth } => {
@@ -2185,9 +2199,9 @@ impl OperatorValidator {
                     self.pop_operand(Some(ty), resources)?;
                 }
                 for ty in label_types(ty, resources, kind)? {
-                    self.push_operand(ty)?;
+                    self.push_operand(ty, resources)?;
                 }
-                self.push_operand(non_null)?
+                self.push_operand(non_null, resources)?
             }
             Operator::BrOnNonNull { relative_depth } => {
                 self.check_function_references_enabled()?;
@@ -2219,7 +2233,7 @@ impl OperatorValidator {
                     self.pop_operand(Some(ty), resources)?;
                 }
                 for ty in t_star {
-                    self.push_operand(ty)?;
+                    self.push_operand(ty, resources)?;
                 }
             }
             Operator::ReturnCallRef => {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -249,7 +249,9 @@ impl TestState {
     fn test_wast_directive(&self, test: &Path, directive: WastDirective) -> Result<()> {
         // Only test parsing and encoding of modules which wasmparser doesn't
         // support test (basically just test `wast`, nothing else)
-        let skip_verify = test.iter().any(|t| t == "function-references" || t == "gc");
+        let skip_verify = test.iter().any(|t| t == "gc")
+            || (test.iter().any(|t| t == "function-references")
+                && test.iter().all(|t| t != "call_ref.wast"));
 
         match directive {
             WastDirective::Wat(mut module) => {
@@ -456,6 +458,7 @@ impl TestState {
                 "component-model" => features.component_model = true,
                 "multi-memory" => features.multi_memory = true,
                 "extended-const" => features.extended_const = true,
+                "function-references" => features.function_references = true,
                 _ => {}
             }
         }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -251,9 +251,17 @@ impl TestState {
         // support test (basically just test `wast`, nothing else)
         let skip_verify = test.iter().any(|t| t == "gc")
             || (test.iter().any(|t| t == "function-references")
-                && test
-                    .iter()
-                    .all(|t| t != "ref_as_non_null.wast" && t != "call_ref.wast"));
+                && test.iter().all(|t| {
+                    t != "ref_as_non_null.wast"
+                        && t != "call_ref.wast"
+                        && t != "br_on_null.wast"
+                        && t != "br_on_non_null.wast"
+                        && t != "ref_func.wast"
+                    //&& t != "ref.wast"
+                    //&& t != "func.wast"
+                    //&& t != "br_table.wast"
+                    //&& t != "binary.wast"
+                }));
 
         match directive {
             WastDirective::Wat(mut module) => {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -257,7 +257,7 @@ impl TestState {
                         && t != "br_on_null.wast"
                         && t != "br_on_non_null.wast"
                         && t != "ref_func.wast"
-                    //&& t != "ref.wast"
+                        && t != "ref.wast"
                     //&& t != "func.wast"
                     //&& t != "br_table.wast"
                     //&& t != "binary.wast"

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -251,7 +251,9 @@ impl TestState {
         // support test (basically just test `wast`, nothing else)
         let skip_verify = test.iter().any(|t| t == "gc")
             || (test.iter().any(|t| t == "function-references")
-                && test.iter().all(|t| t != "call_ref.wast"));
+                && test
+                    .iter()
+                    .all(|t| t != "ref_as_non_null.wast" && t != "call_ref.wast"));
 
         match directive {
             WastDirective::Wat(mut module) => {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -258,11 +258,17 @@ impl TestState {
                         || t == "let-bad.wast"
                         || t == "func_bind.wast"
                         // These should work as far as i know, but don't yet
+                        // Needs subtyping on elements (Daniel has lock on subtyping)
                         || t == "ref_is_null.wast"
+                        // Needs subtyping on elements too, i think
                         || t == "br_table.wast"
+                        // The test seems to assume parsing occurs before validation
                         || t == "binary.wast"
+                        // ????
                         || t == "type-equivalence.wast"
+                        // ????
                         || t == "table.wast"
+                        // ????
                         || t == "table-sub.wast"
                 }));
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -251,16 +251,19 @@ impl TestState {
         // support test (basically just test `wast`, nothing else)
         let skip_verify = test.iter().any(|t| t == "gc")
             || (test.iter().any(|t| t == "function-references")
-                && test.iter().all(|t| {
-                    t != "ref_as_non_null.wast"
-                        && t != "call_ref.wast"
-                        && t != "br_on_null.wast"
-                        && t != "br_on_non_null.wast"
-                        && t != "ref_func.wast"
-                        && t != "ref.wast"
-                        && t != "func.wast"
-                    //&& t != "br_table.wast"
-                    //&& t != "binary.wast"
+                && test.iter().any(|t| {
+                    // These shouldn't pass (we don't plan to support them as
+                    // they are in spec limbo)
+                    t == "let.wast"
+                        || t == "let-bad.wast"
+                        || t == "func_bind.wast"
+                        // These should work as far as i know, but don't yet
+                        || t == "ref_is_null.wast"
+                        || t == "br_table.wast"
+                        || t == "binary.wast"
+                        || t == "type-equivalence.wast"
+                        || t == "table.wast"
+                        || t == "table-sub.wast"
                 }));
 
         match directive {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -258,7 +258,7 @@ impl TestState {
                         && t != "br_on_non_null.wast"
                         && t != "ref_func.wast"
                         && t != "ref.wast"
-                    //&& t != "func.wast"
+                        && t != "func.wast"
                     //&& t != "br_table.wast"
                     //&& t != "binary.wast"
                 }));


### PR DESCRIPTION
This adds the static semantics for the function references instructions we added. It also includes some other changes to existing validation in the function references proposal. Further changes to validation need to be made, at least including adding subtyping to more places.