### PR TITLE
Pass the test suite!

### DIFF
--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -31,9 +31,6 @@ pub enum ValType {
     /// implementation that implements reference types but not function
     /// references. When function references are enabled, there is no
     /// difference, but the distinction is maintained.
-    ///
-    /// Part of the reference types proposal when used anywhere other than a
-    /// table's element type.
     Ref(RefType),
 }
 
@@ -52,7 +49,9 @@ impl Encode for ValType {
     }
 }
 
-/// Part of the typed function references proposal.
+/// Part of the function references proposal. These types are only produced
+/// when the feature is enabled, despite sometimes being equivalent to FuncRef,
+/// because they're encoded differently.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct RefType {
     nullable: bool,
@@ -70,7 +69,7 @@ impl Encode for RefType {
     }
 }
 
-/// Part of the typed function references proposal.
+/// Part of the function references proposal.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum HeapType {
     /// A function reference. When nullable, equivalent to `funcref`

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -296,9 +296,12 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
                 .into(),
             table.default(),
         ),
+        O::BrOnNull { relative_depth } => I::BrOnNull(*relative_depth),
+        O::BrOnNonNull { relative_depth } => I::BrOnNonNull(*relative_depth),
 
         O::Return => I::Return,
         O::Call { function_index } => I::Call(t.remap(Item::Function, *function_index)?),
+        O::CallRef => I::CallRef,
         O::CallIndirect {
             index,
             table_index,
@@ -307,6 +310,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
             ty: t.remap(Item::Type, *index)?,
             table: t.remap(Item::Table, *table_index)?,
         },
+        O::ReturnCallRef => I::ReturnCallRef,
         O::Delegate { relative_depth } => I::Delegate(*relative_depth),
         O::CatchAll => I::CatchAll,
         O::Drop => I::Drop,
@@ -355,6 +359,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         O::RefNull { ty } => I::RefNull(t.translate_ty(ty)?),
         O::RefIsNull => I::RefIsNull,
         O::RefFunc { function_index } => I::RefFunc(t.remap(Item::Function, *function_index)?),
+        O::RefAsNonNull => I::RefAsNonNull,
 
         O::I32Eqz => I::I32Eqz,
         O::I32Eq => I::I32Eq,
@@ -917,14 +922,6 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         | O::ReturnCall { .. }
         | O::ReturnCallIndirect { .. }
         | O::AtomicFence { .. } => return Err(Error::no_mutations_applicable()),
-
-        // Function references proposal instructions. TODO(dhil):
-        // Merge with the above list.
-        O::CallRef => I::CallRef,
-        O::ReturnCallRef => I::ReturnCallRef,
-        O::RefAsNonNull => I::RefAsNonNull,
-        O::BrOnNull { relative_depth } => I::BrOnNull(*relative_depth),
-        O::BrOnNonNull { relative_depth } => I::BrOnNonNull(*relative_depth),
     })
 }
 

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1669,6 +1669,8 @@ impl<'a> BinaryReader<'a> {
                 index: self.read_var_u32()?,
                 table_index: self.read_var_u32()?,
             },
+            0x14 => Operator::CallRef,
+            0x15 => Operator::ReturnCallRef,
             0x18 => Operator::Delegate {
                 relative_depth: self.read_var_u32()?,
             },
@@ -1934,15 +1936,6 @@ impl<'a> BinaryReader<'a> {
             0xd2 => Operator::RefFunc {
                 function_index: self.read_var_u32()?,
             },
-
-            0xfc => self.read_0xfc_operator()?,
-            0xfd => self.read_0xfd_operator()?,
-            0xfe => self.read_0xfe_operator()?,
-
-            // Function references proposal operators. TODO(dhil): Put
-            // each into its appropriate place within the above list.
-            0x14 => Operator::CallRef,
-            0x15 => Operator::ReturnCallRef,
             0xd3 => Operator::RefAsNonNull,
             0xd4 => Operator::BrOnNull {
                 relative_depth: self.read_var_u32()?,
@@ -1950,6 +1943,10 @@ impl<'a> BinaryReader<'a> {
             0xd6 => Operator::BrOnNonNull {
                 relative_depth: self.read_var_u32()?,
             },
+
+            0xfc => self.read_0xfc_operator()?,
+            0xfd => self.read_0xfd_operator()?,
+            0xfe => self.read_0xfe_operator()?,
 
             _ => {
                 return Err(BinaryReaderError::new(

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -143,10 +143,17 @@ pub enum Operator<'a> {
     BrTable {
         table: BrTable<'a>,
     },
+    BrOnNull {
+        relative_depth: u32,
+    },
+    BrOnNonNull {
+        relative_depth: u32,
+    },
     Return,
     Call {
         function_index: u32,
     },
+    CallRef,
     CallIndirect {
         index: u32,
         table_index: u32,
@@ -155,6 +162,7 @@ pub enum Operator<'a> {
     ReturnCall {
         function_index: u32,
     },
+    ReturnCallRef,
     ReturnCallIndirect {
         index: u32,
         table_index: u32,
@@ -279,6 +287,7 @@ pub enum Operator<'a> {
     RefFunc {
         function_index: u32,
     },
+    RefAsNonNull,
     I32Eqz,
     I32Eq,
     I32Ne,
@@ -1005,18 +1014,6 @@ pub enum Operator<'a> {
     F32x4RelaxedMax,
     F64x2RelaxedMin,
     F64x2RelaxedMax,
-
-    // Function references proposal operators. TODO(dhil): Put into
-    // appropriate places in the above list.
-    CallRef,
-    ReturnCallRef,
-    RefAsNonNull,
-    BrOnNull {
-        relative_depth: u32,
-    },
-    BrOnNonNull {
-        relative_depth: u32,
-    },
 }
 
 /// A reader for a core WebAssembly function's operators.

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -38,7 +38,9 @@ pub enum ValType {
     Bot,
 }
 
-/// Reference type from function references
+/// A reference type. When the function references feature is disabled, this
+/// only represents funcref and externref, using the following format:
+/// RefType { nullable: true, heap_type: Func | Extern })
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RefType {
     /// Whether it's nullable
@@ -47,7 +49,8 @@ pub struct RefType {
     pub heap_type: HeapType,
 }
 
-/// See proposal
+/// A heap type from function references. When the proposal is disabled, Index
+/// is an invalid type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum HeapType {
     /// It seems by example that u32s are directly used for arbitrary indexes,
@@ -61,12 +64,14 @@ pub enum HeapType {
     Bot,
 }
 
-/// An internal shortcut for the desugaring of (funcref)
+/// funcref, in both reference types and function references, represented
+/// using the general ref syntax
 pub(crate) const FUNC_REF: RefType = RefType {
     nullable: true,
     heap_type: HeapType::Func,
 };
-/// An internal shortcut for the desugaring of (externref)
+/// externref, in both reference types and function references, represented
+/// using the general ref syntax
 pub(crate) const EXTERN_REF: RefType = RefType {
     nullable: true,
     heap_type: HeapType::Extern,

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -217,7 +217,8 @@ pub trait WasmModuleResources {
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType>;
     /// Returns the element type at the given index.
     fn element_type_at(&self, at: u32) -> Option<RefType>;
-    /// Returns whether t1 <= t2 under function references proposal
+    /// Under the function references proposal, returns whether t1 <=
+    /// t2. Otherwise, returns whether t1 == t2
     fn matches(&self, t1: ValType, t2: ValType) -> bool;
     /// Check a value type. This requires using func_type_at to check references
     fn check_value_type(

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -600,6 +600,12 @@ impl Module {
         types: &TypeList,
         offset: usize,
     ) -> Result<()> {
+        if !ty.element_type.nullable {
+            return Err(BinaryReaderError::new(
+                "non-defaultable element type",
+                offset,
+            ));
+        }
         match ty.element_type.heap_type {
             HeapType::Func => {}
             HeapType::Extern => {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -736,16 +736,44 @@ impl Module {
         Ok(())
     }
 
-    pub(crate) fn matches(&self, ty1: ValType, ty2: ValType, types: &TypeList) -> bool {
-        fn eq_fns(f1: &impl WasmFuncType, f2: &impl WasmFuncType) -> bool {
-            f1.len_inputs() == f2.len_inputs()
-                && f2.len_outputs() == f2.len_outputs()
-                && f1.inputs().zip(f2.inputs()).all(|(t1, t2)| t1 == t2)
-                && f1.outputs().zip(f2.outputs()).all(|(t1, t2)| t1 == t2)
+    fn eq_valtypes(&self, ty1: ValType, ty2: ValType, types: &TypeList) -> bool {
+        match (ty1, ty2) {
+            (ValType::Ref(rt1), ValType::Ref(rt2)) => {
+                rt1.nullable == rt2.nullable
+                    && match (rt1.heap_type, rt2.heap_type) {
+                        (HeapType::Func, HeapType::Func) => true,
+                        (HeapType::Extern, HeapType::Extern) => true,
+                        (HeapType::Index(n1), HeapType::Index(n2)) => {
+                            let n1 = self
+                                .func_type_at(n1, types, 0)
+                                .expect("TODO fixme bad type");
+                            let n2 = self
+                                .func_type_at(n2, types, 0)
+                                .expect("TODO fixme bad type");
+                            self.eq_fns(n1, n2, types)
+                        }
+                        (_, _) => false,
+                    }
+            }
+            _ => ty1 == ty2,
         }
+    }
+    fn eq_fns(&self, f1: &impl WasmFuncType, f2: &impl WasmFuncType, types: &TypeList) -> bool {
+        f1.len_inputs() == f2.len_inputs()
+            && f2.len_outputs() == f2.len_outputs()
+            && f1
+                .inputs()
+                .zip(f2.inputs())
+                .all(|(t1, t2)| self.eq_valtypes(t1, t2, types))
+            && f1
+                .outputs()
+                .zip(f2.outputs())
+                .all(|(t1, t2)| self.eq_valtypes(t1, t2, types))
+    }
 
+    pub(crate) fn matches(&self, ty1: ValType, ty2: ValType, types: &TypeList) -> bool {
         fn matches_null(null1: bool, null2: bool) -> bool {
-            null1 == null2 || null2
+            (null1 == null2) || null2
         }
 
         let matches_heap = |ty1: HeapType, ty2: HeapType, types: &TypeList| -> bool {
@@ -758,7 +786,7 @@ impl Module {
                     let n2 = self
                         .func_type_at(n2, types, 0)
                         .expect("TODO fixme bad type");
-                    eq_fns(n1, n2)
+                    self.eq_fns(n1, n2, types)
                 }
                 (HeapType::Index(_), HeapType::Func) => true,
                 (HeapType::Bot, _) => true,

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -853,20 +853,19 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::I32), resources)?;
                 let ty1 = self.pop_operand(None, resources)?;
                 let ty2 = self.pop_operand(None, resources)?;
-                fn is_num_opt(ty: Option<ValType>) -> bool {
-                    match ty {
-                        None => true,
-                        Some(ty) => matches!(
-                            ty,
-                            ValType::I32
-                                | ValType::I64
-                                | ValType::F32
-                                | ValType::F64
-                                | ValType::Bot
-                        ),
-                    }
+                fn is_num(ty: Option<ValType>) -> bool {
+                    matches!(
+                        ty,
+                        Some(ValType::I32)
+                            | Some(ValType::I64)
+                            | Some(ValType::F32)
+                            | Some(ValType::F64)
+                            | Some(ValType::V128)
+                            | Some(ValType::Bot)
+                            | None
+                    )
                 }
-                if !is_num_opt(ty1) || !is_num_opt(ty2) {
+                if !is_num(ty1) || !is_num(ty2) {
                     bail_op_err!("type mismatch: select only takes integral types")
                 }
                 if ty1 != ty2 && ty1 != None && ty2 != None {

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2097,7 +2097,10 @@ impl OperatorValidator {
                         (Some(a), Some(b)) => (a, b),
                         _ => return Err(OperatorValidatorError::new("table index out of bounds")),
                     };
-                if src.element_type != dst.element_type {
+                if !resources.matches(
+                    ValType::Ref(src.element_type),
+                    ValType::Ref(dst.element_type),
+                ) {
                     return Err(OperatorValidatorError::new("type mismatch"));
                 }
                 self.pop_operand(Some(ValType::I32), resources)?;

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -80,6 +80,7 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
 
     const FEATURES: &[(&str, fn(&mut WasmFeatures) -> &mut bool)] = &[
         ("reference-types", |f| &mut f.reference_types),
+        ("function-references", |f| &mut f.function_references),
         ("simd", |f| &mut f.simd),
         ("threads", |f| &mut f.threads),
         ("bulk-memory", |f| &mut f.bulk_memory),

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -264,8 +264,6 @@ impl TestState {
                         // ????
                         || t == "type-equivalence.wast"
                         // ????
-                        || t == "table.wast"
-                        // ????
                         || t == "table-sub.wast"
                 }));
 
@@ -327,7 +325,7 @@ impl TestState {
                 }
                 match result {
                     Ok(_) => bail!(
-                        "parsed successfully but should have failed with: {}",
+                        "encoded and validated successfully but should have failed with: {}",
                         message,
                     ),
                     Err(e) => {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -263,8 +263,6 @@ impl TestState {
                         // These should work as far as i know, but don't yet
                         // ????
                         || t == "type-equivalence.wast"
-                        // ????
-                        || t == "table-sub.wast"
                 }));
 
         match directive {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -257,9 +257,10 @@ impl TestState {
                     t == "let.wast"
                         || t == "let-bad.wast"
                         || t == "func_bind.wast"
-                        // These should work as far as i know, but don't yet
-                        // ???
+                        // I think this test may be broken or out of sync with the spec
+                        // https://bytecodealliance.zulipchat.com/#narrow/stream/329587-wasmfx/topic/br_table.2Ewast.20.2F.20.28table.20.2E.2E.2E.20.28elem.20.2E.2E.2E.29.29.20issue/near/290806324
                         || t == "br_table.wast"
+                        // These should work as far as i know, but don't yet
                         // The test seems to assume parsing occurs before validation
                         || t == "binary.wast"
                         // ????

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -260,9 +260,6 @@ impl TestState {
                         // I think this test may be broken or out of sync with the spec
                         // https://bytecodealliance.zulipchat.com/#narrow/stream/329587-wasmfx/topic/br_table.2Ewast.20.2F.20.28table.20.2E.2E.2E.20.28elem.20.2E.2E.2E.29.29.20issue/near/290806324
                         || t == "br_table.wast"
-                        // These should work as far as i know, but don't yet
-                        // ????
-                        || t == "type-equivalence.wast"
                 }));
 
         match directive {


### PR DESCRIPTION
- Resolve V128 V128.   These weren't around when the proposal was forked, so I did the "reasonable thing"
- Require defaultable table types as in Rossberg's spec changes
- Fix table.copy to use subtyping as in the spec
- Use the required deep structural equivalence in the subtyping implementation (we were using index equality).   I think implementing this was informative:  structural equivalence IIRC was chosen to simplify the spec. But its implementation is even more painful than I imagine an ostensibly more complicated recursive subtyping relation would be.

There is some significant cleanup that needs to be done on comments, code order and such, but then I think we've done well here.   After some amount of that I would love to have these changes reviewed by wasmtime folks.   Recall that we currently only support the "core" crates (parse,validate,print,dump,objdump)