### PR TITLE
Initial attempt at internalising ValType::Bot

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -201,7 +201,6 @@ impl<'a> TypeEncoder<'a> {
             wasmparser::ValType::F64 => ValType::F64,
             wasmparser::ValType::V128 => ValType::V128,
             wasmparser::ValType::Ref(ty) => Self::ref_type(ty),
-            wasmparser::ValType::Bot => unimplemented!(),
         }
     }
 

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -35,7 +35,6 @@ impl From<wasmparser::ValType> for PrimitiveTypeInfo {
             wasmparser::ValType::F64 => PrimitiveTypeInfo::F64,
             wasmparser::ValType::V128 => PrimitiveTypeInfo::V128,
             wasmparser::ValType::Ref(t) => t.into(),
-            wasmparser::ValType::Bot => unreachable!(),
         }
     }
 }
@@ -79,7 +78,6 @@ pub fn map_type(tpe: wasmparser::ValType) -> Result<ValType> {
         wasmparser::ValType::F64 => Ok(ValType::F64),
         wasmparser::ValType::V128 => Ok(ValType::V128),
         wasmparser::ValType::Ref(t) => map_ref_type(t),
-        wasmparser::ValType::Bot => unimplemented!(),
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -125,7 +125,6 @@ impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
                 T::Ref(wasmparser::FUNC_REF) => CE::ref_null(wasm_encoder::ValType::FuncRef),
                 T::Ref(wasmparser::EXTERN_REF) => CE::ref_null(wasm_encoder::ValType::ExternRef),
                 T::Ref(_) => unimplemented!(),
-                T::Bot => unreachable!(),
             }
         } else {
             // FIXME: implement non-reducing mutations for constant expressions.

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1572,7 +1572,6 @@ fn convert_type(parsed_type: wasmparser::ValType) -> ValType {
         F64 => ValType::F64,
         V128 => ValType::V128,
         Ref(ty) => convert_reftype(ty),
-        Bot => unreachable!(),
     }
 }
 

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -35,8 +35,6 @@ pub enum ValType {
     /// which now provides FuncRef and ExternRef as sugar for the generic ref
     /// construct.
     Ref(RefType),
-    /// Special bottom type.
-    Bot,
 }
 
 /// A reference type. When the function references feature is disabled, this
@@ -61,7 +59,7 @@ pub enum HeapType {
     Func,
     /// From reference types
     Extern,
-    /// Special bottom heap type
+    /// Special bottom type
     Bot,
 }
 

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -219,7 +219,7 @@ pub trait WasmModuleResources {
     fn element_type_at(&self, at: u32) -> Option<RefType>;
     /// Under the function references proposal, returns whether t1 <=
     /// t2. Otherwise, returns whether t1 == t2
-    fn matches(&self, t1: ValType, t2: ValType) -> bool;
+    fn matches(&self, t1: Option<ValType>, t2: Option<ValType>) -> bool;
     /// Check a value type. This requires using func_type_at to check references
     fn check_value_type(
         &self,
@@ -275,7 +275,7 @@ where
     fn element_type_at(&self, at: u32) -> Option<RefType> {
         T::element_type_at(self, at)
     }
-    fn matches(&self, t1: ValType, t2: ValType) -> bool {
+    fn matches(&self, t1: Option<ValType>, t2: Option<ValType>) -> bool {
         T::matches(self, t1, t2)
     }
 
@@ -337,7 +337,7 @@ where
         T::element_type_at(self, at)
     }
 
-    fn matches(&self, t1: ValType, t2: ValType) -> bool {
+    fn matches(&self, t1: Option<ValType>, t2: Option<ValType>) -> bool {
         T::matches(self, t1, t2)
     }
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -242,7 +242,7 @@ impl WasmFeatures {
     /// types. Use module.check_value_type.
     pub(crate) fn check_value_type(&self, ty: ValType) -> Result<(), &'static str> {
         match ty {
-            ValType::Bot | ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => Ok(()),
+            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => Ok(()),
             ValType::Ref(r) => {
                 if self.reference_types {
                     if !self.function_references {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -207,7 +207,7 @@ mod tests {
         fn element_type_at(&self, _at: u32) -> Option<crate::RefType> {
             todo!()
         }
-        fn matches(&self, _t1: ValType, _t2: ValType) -> bool {
+        fn matches(&self, _t1: Option<ValType>, _t2: Option<ValType>) -> bool {
             todo!()
         }
         fn element_count(&self) -> u32 {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -651,7 +651,6 @@ impl Printer {
             ValType::F64 => self.result.push_str("f64"),
             ValType::V128 => self.result.push_str("v128"),
             ValType::Ref(rt) => self.print_reftype(rt)?,
-            ValType::Bot => self.result.push_str("bot"),
         }
         Ok(())
     }


### PR DESCRIPTION
I am not too happy about the representation of `HeapType::Bot`. I wonder whether we can embed it in `HeapType::Index`, though, I would wait with that until we have merged your packed type patch.

Backwards compatibility: I still need to check that I haven't broken the previous public interface.