### PR TITLE
Backport some changes from `function-references`.

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -159,14 +159,22 @@ impl<'a> TypeEncoder<'a> {
             wasmparser::ValType::F32 => ValType::F32,
             wasmparser::ValType::F64 => ValType::F64,
             wasmparser::ValType::V128 => ValType::V128,
-            wasmparser::ValType::FuncRef => ValType::FuncRef,
-            wasmparser::ValType::ExternRef => ValType::ExternRef,
+            wasmparser::ValType::Ref(ty) => Self::ref_type(ty),
+            wasmparser::ValType::Bot => unimplemented!(),
+        }
+    }
+
+    fn ref_type(ty: wasmparser::RefType) -> ValType {
+        match ty {
+            wasmparser::FUNC_REF => ValType::FuncRef,
+            wasmparser::EXTERN_REF => ValType::ExternRef,
+            _ => unimplemented!(),
         }
     }
 
     fn table_type(ty: wasmparser::TableType) -> TableType {
         TableType {
-            element_type: Self::val_type(ty.element_type),
+            element_type: Self::ref_type(ty.element_type),
             minimum: ty.initial,
             maximum: ty.maximum,
         }

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -34,8 +34,18 @@ impl From<wasmparser::ValType> for PrimitiveTypeInfo {
             wasmparser::ValType::F32 => PrimitiveTypeInfo::F32,
             wasmparser::ValType::F64 => PrimitiveTypeInfo::F64,
             wasmparser::ValType::V128 => PrimitiveTypeInfo::V128,
-            wasmparser::ValType::FuncRef => PrimitiveTypeInfo::FuncRef,
-            wasmparser::ValType::ExternRef => PrimitiveTypeInfo::ExternRef,
+            wasmparser::ValType::Ref(t) => t.into(),
+            wasmparser::ValType::Bot => unreachable!(),
+        }
+    }
+}
+
+impl From<wasmparser::RefType> for PrimitiveTypeInfo {
+    fn from(value: wasmparser::RefType) -> Self {
+        match value {
+            wasmparser::FUNC_REF => PrimitiveTypeInfo::FuncRef,
+            wasmparser::EXTERN_REF => PrimitiveTypeInfo::ExternRef,
+            _ => unimplemented!(),
         }
     }
 }
@@ -68,8 +78,16 @@ pub fn map_type(tpe: wasmparser::ValType) -> Result<ValType> {
         wasmparser::ValType::F32 => Ok(ValType::F32),
         wasmparser::ValType::F64 => Ok(ValType::F64),
         wasmparser::ValType::V128 => Ok(ValType::V128),
-        wasmparser::ValType::FuncRef => Ok(ValType::FuncRef),
-        wasmparser::ValType::ExternRef => Ok(ValType::ExternRef),
+        wasmparser::ValType::Ref(t) => map_ref_type(t),
+        wasmparser::ValType::Bot => unimplemented!(),
+    }
+}
+
+pub fn map_ref_type(tpe: wasmparser::RefType) -> Result<ValType> {
+    match tpe {
+        wasmparser::FUNC_REF => Ok(ValType::FuncRef),
+        wasmparser::EXTERN_REF => Ok(ValType::ExternRef),
+        _ => unimplemented!(),
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -94,8 +94,16 @@ fn translate_type(ty: &wasmparser::ValType) -> Result<wasm_encoder::ValType> {
         wasmparser::ValType::F32 => wasm_encoder::ValType::F32,
         wasmparser::ValType::F64 => wasm_encoder::ValType::F64,
         wasmparser::ValType::V128 => wasm_encoder::ValType::V128,
-        wasmparser::ValType::FuncRef => wasm_encoder::ValType::FuncRef,
-        wasmparser::ValType::ExternRef => wasm_encoder::ValType::ExternRef,
+        wasmparser::ValType::Ref(rt) => translate_ref_type(rt)?,
+        wasmparser::ValType::Bot => unreachable!(),
+    })
+}
+
+fn translate_ref_type(rt: &wasmparser::RefType) -> Result<wasm_encoder::ValType> {
+    Ok(match *rt {
+        wasmparser::FUNC_REF => wasm_encoder::ValType::FuncRef,
+        wasmparser::EXTERN_REF => wasm_encoder::ValType::ExternRef,
+        _ => unimplemented!(),
     })
 }
 

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -122,8 +122,10 @@ impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
                 } else {
                     f64::from_bits(self.config.rng().gen())
                 }),
-                T::FuncRef => CE::ref_null(wasm_encoder::ValType::FuncRef),
-                T::ExternRef => CE::ref_null(wasm_encoder::ValType::ExternRef),
+                T::Ref(wasmparser::FUNC_REF) => CE::ref_null(wasm_encoder::ValType::FuncRef),
+                T::Ref(wasmparser::EXTERN_REF) => CE::ref_null(wasm_encoder::ValType::ExternRef),
+                T::Ref(_) => unimplemented!(),
+                T::Bot => unreachable!(),
             }
         } else {
             // FIXME: implement non-reducing mutations for constant expressions.

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -762,12 +762,12 @@ impl<'a> DFGBuilder {
                 }
 
                 Operator::RefNull {
-                    ty: wasmparser::ValType::ExternRef,
+                    ty: wasmparser::HeapType::Extern,
                 } => {
                     self.push_node(Lang::RefNull(RefType::Extern), idx);
                 }
                 Operator::RefNull {
-                    ty: wasmparser::ValType::FuncRef,
+                    ty: wasmparser::HeapType::Func,
                 } => {
                     self.push_node(Lang::RefNull(RefType::Func), idx);
                 }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -60,6 +60,14 @@ pub trait Translator {
         ty(self.as_obj(), t)
     }
 
+    fn translate_refty(&mut self, t: &wasmparser::RefType) -> Result<ValType> {
+        refty(self.as_obj(), t)
+    }
+
+    fn translate_heapty(&mut self, t: &wasmparser::HeapType) -> Result<ValType> {
+        heapty(self.as_obj(), t)
+    }
+
     fn translate_global(&mut self, g: Global, s: &mut GlobalSection) -> Result<()> {
         global(self.as_obj(), g, s)
     }
@@ -138,7 +146,7 @@ pub fn table_type(
     ty: &wasmparser::TableType,
 ) -> Result<wasm_encoder::TableType> {
     Ok(wasm_encoder::TableType {
-        element_type: t.translate_ty(&ty.element_type)?,
+        element_type: t.translate_refty(&ty.element_type)?,
         minimum: ty.initial,
         maximum: ty.maximum,
     })
@@ -174,14 +182,18 @@ pub fn tag_type(t: &mut dyn Translator, ty: &wasmparser::TagType) -> Result<wasm
 }
 
 pub fn ty(_t: &mut dyn Translator, ty: &wasmparser::ValType) -> Result<ValType> {
+    crate::module::map_type(*ty)
+}
+
+pub fn refty(_t: &mut dyn Translator, ty: &wasmparser::RefType) -> Result<ValType> {
+    crate::module::map_ref_type(*ty)
+}
+
+pub fn heapty(_t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<ValType> {
     match ty {
-        wasmparser::ValType::I32 => Ok(ValType::I32),
-        wasmparser::ValType::I64 => Ok(ValType::I64),
-        wasmparser::ValType::F32 => Ok(ValType::F32),
-        wasmparser::ValType::F64 => Ok(ValType::F64),
-        wasmparser::ValType::V128 => Ok(ValType::V128),
-        wasmparser::ValType::FuncRef => Ok(ValType::FuncRef),
-        wasmparser::ValType::ExternRef => Ok(ValType::ExternRef),
+        wasmparser::HeapType::Func => Ok(ValType::FuncRef),
+        wasmparser::HeapType::Extern => Ok(ValType::ExternRef),
+        _ => unimplemented!(),
     }
 }
 
@@ -208,7 +220,7 @@ pub fn const_expr(
         match op {
             Operator::RefFunc { .. }
             | Operator::RefNull {
-                ty: wasmparser::ValType::FuncRef,
+                ty: wasmparser::HeapType::Func,
                 ..
             }
             | Operator::GlobalGet { .. } => {}
@@ -247,7 +259,7 @@ pub fn element(
         ElementKind::Passive => ElementMode::Passive,
         ElementKind::Declared => ElementMode::Declared,
     };
-    let element_type = t.translate_ty(&element.ty)?;
+    let element_type = t.translate_refty(&element.ty)?;
     let mut functions = Vec::new();
     let mut exprs = Vec::new();
     let mut reader = element.items.get_items_reader()?;
@@ -259,7 +271,7 @@ pub fn element(
             ElementItem::Expr(expr) => {
                 exprs.push(t.translate_const_expr(
                     &expr,
-                    &element.ty,
+                    &wasmparser::ValType::Ref(element.ty),
                     ConstExprKind::ElementFunction,
                 )?);
             }
@@ -367,7 +379,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         O::F32Const { value } => I::F32Const(f32::from_bits(value.bits())),
         O::F64Const { value } => I::F64Const(f64::from_bits(value.bits())),
 
-        O::RefNull { ty } => I::RefNull(t.translate_ty(ty)?),
+        O::RefNull { ty } => I::RefNull(t.translate_heapty(ty)?),
         O::RefIsNull => I::RefIsNull,
         O::RefFunc { function_index } => I::RefFunc(t.remap(Item::Function, *function_index)?),
         O::RefAsNonNull => I::RefAsNonNull,

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -233,6 +233,7 @@ impl ShrinkRun {
             saturating_float_to_int: true,
             sign_extension: true,
             component_model: false,
+            function_references: false,
 
             // We'll never enable this here.
             deterministic_only: false,

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -1799,9 +1799,9 @@ fn inverse_scalar_canonical_abi_for(
             .cloned(),
         ValType::F32 => Ok(ComponentValType::Primitive(PrimitiveValType::Float32)),
         ValType::F64 => Ok(ComponentValType::Primitive(PrimitiveValType::Float64)),
-        ValType::V128 | ValType::FuncRef | ValType::ExternRef => {
+        ValType::V128 | ValType::FuncRef | ValType::ExternRef | ValType::Ref(_) => {
             unreachable!("not used in canonical ABI")
-        }
+        },
     };
 
     let mut param_names = HashSet::default();

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -648,7 +648,7 @@ impl Module {
 
                 wasmparser::TypeRef::Table(table_ty) => {
                     let table_ty = TableType {
-                        element_type: convert_type(table_ty.element_type),
+                        element_type: convert_reftype(table_ty.element_type),
                         minimum: table_ty.initial,
                         maximum: table_ty.maximum,
                     };
@@ -880,7 +880,8 @@ impl Module {
                             } else {
                                 ConstExpr::ref_null(ValType::FuncRef)
                             }
-                        }
+                        },
+                        ValType::Ref(_) => unimplemented!(),
                     }))
                 }));
 
@@ -1564,6 +1565,15 @@ fn convert_type(parsed_type: wasmparser::ValType) -> ValType {
         V128 => ValType::V128,
         FuncRef => ValType::FuncRef,
         ExternRef => ValType::ExternRef,
+    }
+}
+
+/// Convert a wasmparser's `ValType` to a `wasm_encoder::ValType`.
+fn convert_reftype(parsed_type: wasmparser::RefType) -> ValType {
+    match parsed_type {
+        wasmparser::FUNC_REF => ValType::FuncRef,
+        wasmparser::EXTERN_REF => ValType::ExternRef,
+        _ => unimplemented!(),
     }
 }
 

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -1096,6 +1096,7 @@ fn arbitrary_val(ty: ValType, u: &mut Unstructured<'_>) -> Instruction {
         ValType::V128 => Instruction::V128Const(u.arbitrary().unwrap_or(0)),
         ValType::ExternRef => Instruction::RefNull(ValType::ExternRef),
         ValType::FuncRef => Instruction::RefNull(ValType::FuncRef),
+        ValType::Ref(_) => unimplemented!(),
     }
 }
 
@@ -1562,6 +1563,7 @@ fn select(_: &mut Unstructured, _: &Module, builder: &mut CodeBuilder) -> Result
         }
         Some(ValType::I32) | Some(ValType::I64) | Some(ValType::F32) | Some(ValType::F64)
         | Some(ValType::V128) | None => Ok(Instruction::Select),
+        Some(ValType::Ref(_)) => unimplemented!(),
     }
 }
 

--- a/crates/wasm-smith/src/core/notrap.rs
+++ b/crates/wasm-smith/src/core/notrap.rs
@@ -634,6 +634,7 @@ fn dummy_value_inst<'a>(ty: ValType) -> Instruction<'a> {
         ValType::F64 => Instruction::F64Const(0.0),
         ValType::V128 => Instruction::V128Const(0),
         ValType::FuncRef | ValType::ExternRef => Instruction::RefNull(ty),
+        ValType::Ref(_) => unimplemented!(),
     }
 }
 
@@ -808,6 +809,6 @@ fn size_of_type_in_memory(ty: ValType) -> u64 {
         ValType::F32 => 4,
         ValType::F64 => 8,
         ValType::V128 => 16,
-        ValType::FuncRef | ValType::ExternRef => panic!("not a memory type"),
+        ValType::Ref(_) | ValType::FuncRef | ValType::ExternRef => panic!("not a memory type"),
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -66,13 +66,13 @@ pub enum HeapType {
 
 /// funcref, in both reference types and function references, represented
 /// using the general ref syntax
-pub(crate) const FUNC_REF: RefType = RefType {
+pub const FUNC_REF: RefType = RefType {
     nullable: true,
     heap_type: HeapType::Func,
 };
 /// externref, in both reference types and function references, represented
 /// using the general ref syntax
-pub(crate) const EXTERN_REF: RefType = RefType {
+pub const EXTERN_REF: RefType = RefType {
     nullable: true,
     heap_type: HeapType::Extern,
 };


### PR DESCRIPTION
This patch backports changes in the `function-references` branch, which makes it possible to run `cargo check` successfully over the code base.