### PR TITLE
Backport type annotations on `CallRef` and `ReturnCallRef`.

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -322,9 +322,9 @@ pub enum Instruction<'a> {
     BrOnNonNull(u32),
     Return,
     Call(u32),
-    CallRef,
+    CallRef(ValType),
     CallIndirect { ty: u32, table: u32 },
-    ReturnCallRef,
+    ReturnCallRef(ValType),
     Throw(u32),
     Rethrow(u32),
 
@@ -916,13 +916,19 @@ impl Encode for Instruction<'_> {
                 sink.push(0x10);
                 f.encode(sink);
             }
-            Instruction::CallRef => sink.push(0x14),
+            Instruction::CallRef(ty) => {
+                sink.push(0x14);
+                ty.encode(sink);
+            }
             Instruction::CallIndirect { ty, table } => {
                 sink.push(0x11);
                 ty.encode(sink);
                 table.encode(sink);
             }
-            Instruction::ReturnCallRef => sink.push(0x15),
+            Instruction::ReturnCallRef(ty) => {
+                sink.push(0x15);
+                ty.encode(sink);
+            }
             Instruction::Delegate(l) => {
                 sink.push(0x18);
                 l.encode(sink);

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -324,7 +324,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
 
         O::Return => I::Return,
         O::Call { function_index } => I::Call(t.remap(Item::Function, *function_index)?),
-        O::CallRef => I::CallRef,
+        O::CallRef { ty } => I::CallRef(t.translate_heapty(ty)?),
         O::CallIndirect {
             index,
             table_index,
@@ -333,7 +333,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
             ty: t.remap(Item::Type, *index)?,
             table: t.remap(Item::Table, *table_index)?,
         },
-        O::ReturnCallRef => I::ReturnCallRef,
+        O::ReturnCallRef { ty } => I::ReturnCallRef(t.translate_heapty(ty)?),
         O::Delegate { relative_depth } => I::Delegate(*relative_depth),
         O::CatchAll => I::CatchAll,
         O::Drop => I::Drop,

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1669,8 +1669,12 @@ impl<'a> BinaryReader<'a> {
                 index: self.read_var_u32()?,
                 table_index: self.read_var_u32()?,
             },
-            0x14 => Operator::CallRef,
-            0x15 => Operator::ReturnCallRef,
+            0x14 => Operator::CallRef {
+                ty: self.read_heap_type()?,
+            },
+            0x15 => Operator::ReturnCallRef {
+                ty: self.read_heap_type()?,
+            },
             0x18 => Operator::Delegate {
                 relative_depth: self.read_var_u32()?,
             },

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -153,7 +153,7 @@ pub enum Operator<'a> {
     Call {
         function_index: u32,
     },
-    CallRef,
+    CallRef { ty: HeapType },
     CallIndirect {
         index: u32,
         table_index: u32,
@@ -162,7 +162,7 @@ pub enum Operator<'a> {
     ReturnCall {
         function_index: u32,
     },
-    ReturnCallRef,
+    ReturnCallRef { ty: HeapType },
     ReturnCallIndirect {
         index: u32,
         table_index: u32,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1030,7 +1030,10 @@ impl Printer {
                 self.result.push_str("call ");
                 self.print_idx(&state.core.func_names, *function_index)?;
             }
-            CallRef => self.result.push_str("call_ref"),
+            CallRef { ty } => {
+                self.result.push_str("call_ref ");
+                self.print_heaptype(*ty)?;
+            }
             CallIndirect {
                 table_index,
                 index,
@@ -1047,7 +1050,10 @@ impl Printer {
                 self.result.push_str("return_call ");
                 self.print_idx(&state.core.func_names, *function_index)?;
             }
-            ReturnCallRef => self.result.push_str("return_call_ref"),
+            ReturnCallRef { ty } => {
+                self.result.push_str("return_call_ref");
+                self.print_heaptype(*ty)?;
+            }
             ReturnCallIndirect { table_index, index } => {
                 self.result.push_str("return_call_indirect");
                 if *table_index != 0 {


### PR DESCRIPTION
This patch backports the type annotations on `CallRef` and `ReturnCallRef` instructions from the `function-references` branch.

I will update `wasmtime` accordingly later.