### PR TITLE
Rebase on func-ref-2 & add stubs to make `cargo check` succeed.

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -159,14 +159,22 @@ impl<'a> TypeEncoder<'a> {
             wasmparser::ValType::F32 => ValType::F32,
             wasmparser::ValType::F64 => ValType::F64,
             wasmparser::ValType::V128 => ValType::V128,
-            wasmparser::ValType::FuncRef => ValType::FuncRef,
-            wasmparser::ValType::ExternRef => ValType::ExternRef,
+            wasmparser::ValType::Ref(ty) => Self::ref_type(ty),
+            wasmparser::ValType::Bot => unimplemented!(),
+        }
+    }
+
+    fn ref_type(ty: wasmparser::RefType) -> ValType {
+        match ty {
+            wasmparser::FUNC_REF => ValType::FuncRef,
+            wasmparser::EXTERN_REF => ValType::ExternRef,
+            _ => unimplemented!(),
         }
     }
 
     fn table_type(ty: wasmparser::TableType) -> TableType {
         TableType {
-            element_type: Self::val_type(ty.element_type),
+            element_type: Self::ref_type(ty.element_type),
             minimum: ty.initial,
             maximum: ty.maximum,
         }

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -322,9 +322,9 @@ pub enum Instruction<'a> {
     BrOnNonNull(u32),
     Return,
     Call(u32),
-    CallRef,
+    CallRef(ValType),
     CallIndirect { ty: u32, table: u32 },
-    ReturnCallRef,
+    ReturnCallRef(ValType),
     Throw(u32),
     Rethrow(u32),
 
@@ -916,13 +916,19 @@ impl Encode for Instruction<'_> {
                 sink.push(0x10);
                 f.encode(sink);
             }
-            Instruction::CallRef => sink.push(0x14),
+            Instruction::CallRef(ty) => {
+                sink.push(0x14);
+                ty.encode(sink);
+            }
             Instruction::CallIndirect { ty, table } => {
                 sink.push(0x11);
                 ty.encode(sink);
                 table.encode(sink);
             }
-            Instruction::ReturnCallRef => sink.push(0x15),
+            Instruction::ReturnCallRef(ty) => {
+                sink.push(0x15);
+                ty.encode(sink);
+            }
             Instruction::Delegate(l) => {
                 sink.push(0x18);
                 l.encode(sink);

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -34,8 +34,18 @@ impl From<wasmparser::ValType> for PrimitiveTypeInfo {
             wasmparser::ValType::F32 => PrimitiveTypeInfo::F32,
             wasmparser::ValType::F64 => PrimitiveTypeInfo::F64,
             wasmparser::ValType::V128 => PrimitiveTypeInfo::V128,
-            wasmparser::ValType::FuncRef => PrimitiveTypeInfo::FuncRef,
-            wasmparser::ValType::ExternRef => PrimitiveTypeInfo::ExternRef,
+            wasmparser::ValType::Ref(t) => t.into(),
+            wasmparser::ValType::Bot => unreachable!(),
+        }
+    }
+}
+
+impl From<wasmparser::RefType> for PrimitiveTypeInfo {
+    fn from(value: wasmparser::RefType) -> Self {
+        match value {
+            wasmparser::FUNC_REF => PrimitiveTypeInfo::FuncRef,
+            wasmparser::EXTERN_REF => PrimitiveTypeInfo::ExternRef,
+            _ => unimplemented!(),
         }
     }
 }
@@ -68,8 +78,16 @@ pub fn map_type(tpe: wasmparser::ValType) -> Result<ValType> {
         wasmparser::ValType::F32 => Ok(ValType::F32),
         wasmparser::ValType::F64 => Ok(ValType::F64),
         wasmparser::ValType::V128 => Ok(ValType::V128),
-        wasmparser::ValType::FuncRef => Ok(ValType::FuncRef),
-        wasmparser::ValType::ExternRef => Ok(ValType::ExternRef),
+        wasmparser::ValType::Ref(t) => map_ref_type(t),
+        wasmparser::ValType::Bot => unimplemented!(),
+    }
+}
+
+pub fn map_ref_type(tpe: wasmparser::RefType) -> Result<ValType> {
+    match tpe {
+        wasmparser::FUNC_REF => Ok(ValType::FuncRef),
+        wasmparser::EXTERN_REF => Ok(ValType::ExternRef),
+        _ => unimplemented!(),
     }
 }
 

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -67,6 +67,7 @@ impl TryFrom<wasmparser::Type> for TypeInfo {
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
             })),
+            wasmparser::Type::Cont(_) => unimplemented!(),
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -70,6 +70,7 @@ impl Mutator for AddTypeMutator {
                             .collect::<Result<Vec<_>, _>>()?;
                         types.function(params, results);
                     }
+                    wasmparser::Type::Cont(_) => unimplemented!(),
                 }
             }
             // And then add our new type.

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -94,8 +94,16 @@ fn translate_type(ty: &wasmparser::ValType) -> Result<wasm_encoder::ValType> {
         wasmparser::ValType::F32 => wasm_encoder::ValType::F32,
         wasmparser::ValType::F64 => wasm_encoder::ValType::F64,
         wasmparser::ValType::V128 => wasm_encoder::ValType::V128,
-        wasmparser::ValType::FuncRef => wasm_encoder::ValType::FuncRef,
-        wasmparser::ValType::ExternRef => wasm_encoder::ValType::ExternRef,
+        wasmparser::ValType::Ref(rt) => translate_ref_type(rt)?,
+        wasmparser::ValType::Bot => unreachable!(),
+    })
+}
+
+fn translate_ref_type(rt: &wasmparser::RefType) -> Result<wasm_encoder::ValType> {
+    Ok(match *rt {
+        wasmparser::FUNC_REF => wasm_encoder::ValType::FuncRef,
+        wasmparser::EXTERN_REF => wasm_encoder::ValType::ExternRef,
+        _ => unimplemented!(),
     })
 }
 

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -122,8 +122,10 @@ impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
                 } else {
                     f64::from_bits(self.config.rng().gen())
                 }),
-                T::FuncRef => CE::ref_null(wasm_encoder::ValType::FuncRef),
-                T::ExternRef => CE::ref_null(wasm_encoder::ValType::ExternRef),
+                T::Ref(wasmparser::FUNC_REF) => CE::ref_null(wasm_encoder::ValType::FuncRef),
+                T::Ref(wasmparser::EXTERN_REF) => CE::ref_null(wasm_encoder::ValType::ExternRef),
+                T::Ref(_) => unimplemented!(),
+                T::Bot => unreachable!(),
             }
         } else {
             // FIXME: implement non-reducing mutations for constant expressions.

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -762,12 +762,12 @@ impl<'a> DFGBuilder {
                 }
 
                 Operator::RefNull {
-                    ty: wasmparser::ValType::ExternRef,
+                    ty: wasmparser::HeapType::Extern,
                 } => {
                     self.push_node(Lang::RefNull(RefType::Extern), idx);
                 }
                 Operator::RefNull {
-                    ty: wasmparser::ValType::FuncRef,
+                    ty: wasmparser::HeapType::Func,
                 } => {
                     self.push_node(Lang::RefNull(RefType::Func), idx);
                 }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -324,7 +324,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
 
         O::Return => I::Return,
         O::Call { function_index } => I::Call(t.remap(Item::Function, *function_index)?),
-        O::CallRef => I::CallRef,
+        O::CallRef { ty } => I::CallRef(t.translate_heapty(ty)?),
         O::CallIndirect {
             index,
             table_index,
@@ -333,7 +333,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
             ty: t.remap(Item::Type, *index)?,
             table: t.remap(Item::Table, *table_index)?,
         },
-        O::ReturnCallRef => I::ReturnCallRef,
+        O::ReturnCallRef { ty } => I::ReturnCallRef(t.translate_heapty(ty)?),
         O::Delegate { relative_depth } => I::Delegate(*relative_depth),
         O::CatchAll => I::CatchAll,
         O::Drop => I::Drop,

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -138,6 +138,7 @@ pub fn type_def(t: &mut dyn Translator, ty: Type, s: &mut TypeSection) -> Result
             );
             Ok(())
         }
+        Type::Cont(_) => unimplemented!(),
     }
 }
 
@@ -945,6 +946,9 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         | O::ReturnCall { .. }
         | O::ReturnCallIndirect { .. }
         | O::AtomicFence { .. } => return Err(Error::no_mutations_applicable()),
+
+        // Typed continuations
+        | O::ContNew { .. } | O::ContBind { .. } | O::Suspend { .. } | O::Resume { .. } | O::ResumeThrow { .. } | O::Barrier { .. } => unimplemented!(),
     })
 }
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -60,6 +60,14 @@ pub trait Translator {
         ty(self.as_obj(), t)
     }
 
+    fn translate_refty(&mut self, t: &wasmparser::RefType) -> Result<ValType> {
+        refty(self.as_obj(), t)
+    }
+
+    fn translate_heapty(&mut self, t: &wasmparser::HeapType) -> Result<ValType> {
+        heapty(self.as_obj(), t)
+    }
+
     fn translate_global(&mut self, g: Global, s: &mut GlobalSection) -> Result<()> {
         global(self.as_obj(), g, s)
     }
@@ -138,7 +146,7 @@ pub fn table_type(
     ty: &wasmparser::TableType,
 ) -> Result<wasm_encoder::TableType> {
     Ok(wasm_encoder::TableType {
-        element_type: t.translate_ty(&ty.element_type)?,
+        element_type: t.translate_refty(&ty.element_type)?,
         minimum: ty.initial,
         maximum: ty.maximum,
     })
@@ -174,14 +182,18 @@ pub fn tag_type(t: &mut dyn Translator, ty: &wasmparser::TagType) -> Result<wasm
 }
 
 pub fn ty(_t: &mut dyn Translator, ty: &wasmparser::ValType) -> Result<ValType> {
+    crate::module::map_type(*ty)
+}
+
+pub fn refty(_t: &mut dyn Translator, ty: &wasmparser::RefType) -> Result<ValType> {
+    crate::module::map_ref_type(*ty)
+}
+
+pub fn heapty(_t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<ValType> {
     match ty {
-        wasmparser::ValType::I32 => Ok(ValType::I32),
-        wasmparser::ValType::I64 => Ok(ValType::I64),
-        wasmparser::ValType::F32 => Ok(ValType::F32),
-        wasmparser::ValType::F64 => Ok(ValType::F64),
-        wasmparser::ValType::V128 => Ok(ValType::V128),
-        wasmparser::ValType::FuncRef => Ok(ValType::FuncRef),
-        wasmparser::ValType::ExternRef => Ok(ValType::ExternRef),
+        wasmparser::HeapType::Func => Ok(ValType::FuncRef),
+        wasmparser::HeapType::Extern => Ok(ValType::ExternRef),
+        _ => unimplemented!(),
     }
 }
 
@@ -208,7 +220,7 @@ pub fn const_expr(
         match op {
             Operator::RefFunc { .. }
             | Operator::RefNull {
-                ty: wasmparser::ValType::FuncRef,
+                ty: wasmparser::HeapType::Func,
                 ..
             }
             | Operator::GlobalGet { .. } => {}
@@ -247,7 +259,7 @@ pub fn element(
         ElementKind::Passive => ElementMode::Passive,
         ElementKind::Declared => ElementMode::Declared,
     };
-    let element_type = t.translate_ty(&element.ty)?;
+    let element_type = t.translate_refty(&element.ty)?;
     let mut functions = Vec::new();
     let mut exprs = Vec::new();
     let mut reader = element.items.get_items_reader()?;
@@ -259,7 +271,7 @@ pub fn element(
             ElementItem::Expr(expr) => {
                 exprs.push(t.translate_const_expr(
                     &expr,
-                    &element.ty,
+                    &wasmparser::ValType::Ref(element.ty),
                     ConstExprKind::ElementFunction,
                 )?);
             }
@@ -367,7 +379,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         O::F32Const { value } => I::F32Const(f32::from_bits(value.bits())),
         O::F64Const { value } => I::F64Const(f64::from_bits(value.bits())),
 
-        O::RefNull { ty } => I::RefNull(t.translate_ty(ty)?),
+        O::RefNull { ty } => I::RefNull(t.translate_heapty(ty)?),
         O::RefIsNull => I::RefIsNull,
         O::RefFunc { function_index } => I::RefFunc(t.remap(Item::Function, *function_index)?),
         O::RefAsNonNull => I::RefAsNonNull,

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -234,6 +234,7 @@ impl ShrinkRun {
             sign_extension: true,
             component_model: false,
             function_references: false,
+            typed_continuations: false,
 
             // We'll never enable this here.
             deterministic_only: false,

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -233,6 +233,7 @@ impl ShrinkRun {
             saturating_float_to_int: true,
             sign_extension: true,
             component_model: false,
+            function_references: false,
 
             // We'll never enable this here.
             deterministic_only: false,

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -1799,9 +1799,9 @@ fn inverse_scalar_canonical_abi_for(
             .cloned(),
         ValType::F32 => Ok(ComponentValType::Primitive(PrimitiveValType::Float32)),
         ValType::F64 => Ok(ComponentValType::Primitive(PrimitiveValType::Float64)),
-        ValType::V128 | ValType::FuncRef | ValType::ExternRef => {
+        ValType::V128 | ValType::FuncRef | ValType::ExternRef | ValType::Ref(_) => {
             unreachable!("not used in canonical ABI")
-        }
+        },
     };
 
     let mut param_names = HashSet::default();

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -648,7 +648,7 @@ impl Module {
 
                 wasmparser::TypeRef::Table(table_ty) => {
                     let table_ty = TableType {
-                        element_type: convert_type(table_ty.element_type),
+                        element_type: convert_reftype(table_ty.element_type),
                         minimum: table_ty.initial,
                         maximum: table_ty.maximum,
                     };
@@ -880,7 +880,8 @@ impl Module {
                             } else {
                                 ConstExpr::ref_null(ValType::FuncRef)
                             }
-                        }
+                        },
+                        ValType::Ref(_) => unimplemented!(),
                     }))
                 }));
 
@@ -1564,6 +1565,15 @@ fn convert_type(parsed_type: wasmparser::ValType) -> ValType {
         V128 => ValType::V128,
         FuncRef => ValType::FuncRef,
         ExternRef => ValType::ExternRef,
+    }
+}
+
+/// Convert a wasmparser's `ValType` to a `wasm_encoder::ValType`.
+fn convert_reftype(parsed_type: wasmparser::RefType) -> ValType {
+    match parsed_type {
+        wasmparser::FUNC_REF => ValType::FuncRef,
+        wasmparser::EXTERN_REF => ValType::ExternRef,
+        _ => unimplemented!(),
     }
 }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -602,6 +602,7 @@ impl Module {
                     new_types.push(Type::Func(Rc::clone(&func_type)));
                     new_index
                 }
+                Some((wasmparser::Type::Cont(_), _)) => unimplemented!(),
             };
             match &new_types[serialized_sig_idx - first_type_index] {
                 Type::Func(f) => Some((serialized_sig_idx as u32, Rc::clone(f))),

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -1096,6 +1096,7 @@ fn arbitrary_val(ty: ValType, u: &mut Unstructured<'_>) -> Instruction {
         ValType::V128 => Instruction::V128Const(u.arbitrary().unwrap_or(0)),
         ValType::ExternRef => Instruction::RefNull(ValType::ExternRef),
         ValType::FuncRef => Instruction::RefNull(ValType::FuncRef),
+        ValType::Ref(_) => unimplemented!(),
     }
 }
 
@@ -1562,6 +1563,7 @@ fn select(_: &mut Unstructured, _: &Module, builder: &mut CodeBuilder) -> Result
         }
         Some(ValType::I32) | Some(ValType::I64) | Some(ValType::F32) | Some(ValType::F64)
         | Some(ValType::V128) | None => Ok(Instruction::Select),
+        Some(ValType::Ref(_)) => unimplemented!(),
     }
 }
 

--- a/crates/wasm-smith/src/core/notrap.rs
+++ b/crates/wasm-smith/src/core/notrap.rs
@@ -634,6 +634,7 @@ fn dummy_value_inst<'a>(ty: ValType) -> Instruction<'a> {
         ValType::F64 => Instruction::F64Const(0.0),
         ValType::V128 => Instruction::V128Const(0),
         ValType::FuncRef | ValType::ExternRef => Instruction::RefNull(ty),
+        ValType::Ref(_) => unimplemented!(),
     }
 }
 
@@ -808,6 +809,6 @@ fn size_of_type_in_memory(ty: ValType) -> u64 {
         ValType::F32 => 4,
         ValType::F64 => 8,
         ValType::V128 => 16,
-        ValType::FuncRef | ValType::ExternRef => panic!("not a memory type"),
+        ValType::Ref(_) | ValType::FuncRef | ValType::ExternRef => panic!("not a memory type"),
     }
 }

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -258,6 +258,7 @@ fn validate_benchmark(c: &mut Criterion) {
             mutable_global: true,
             saturating_float_to_int: true,
             sign_extension: true,
+            function_references: true,
         })
     }
     let mut inputs = collect_benchmark_inputs();

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -817,16 +817,22 @@ impl<'a> BinaryReader<'a> {
 
     pub(crate) fn read_tag_type(&mut self) -> Result<TagType> {
         let attribute = self.read_u8()?;
-        if attribute != 0 {
-            return Err(BinaryReaderError::new(
-                "invalid tag attributes",
-                self.original_position() - 1,
-            ));
+        match attribute {
+            0 => Ok(TagType {
+                kind: TagKind::Exception,
+                func_type_idx: self.read_var_u32()?,
+            }),
+            1 => Ok(TagType {
+                kind: TagKind::Control,
+                func_type_idx: self.read_var_u32()?,
+            }),
+            _ => {
+                return Err(BinaryReaderError::new(
+                    "invalid tag attributes",
+                    self.original_position() - 1,
+                ));
+            }
         }
-        Ok(TagType {
-            kind: TagKind::Exception,
-            func_type_idx: self.read_var_u32()?,
-        })
     }
 
     pub(crate) fn read_global_type(&mut self) -> Result<GlobalType> {

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -295,7 +295,7 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_type(&mut self) -> Result<Type> {
         Ok(match self.read_u8()? {
             0x60 => Type::Func(self.read_func_type()?),
-            0x5f => Type::Cont(self.read_u32()?),
+            0x5f => Type::Cont(self.read_var_u32()?),
             x => return self.invalid_leading_byte(x, "type"),
         })
     }
@@ -944,7 +944,7 @@ impl<'a> BinaryReader<'a> {
     fn read_resume_table(&mut self) -> Result<ResumeTable<'a>> {
         let cnt = self.read_size(MAX_WASM_RESUME_TABLE_SIZE, "resume_table")?;
         let start = self.position;
-        for _ in 0..(cnt*2) {
+        for _ in 0..(cnt * 2) {
             self.read_var_u32()?;
         }
         let end = self.position;
@@ -2661,7 +2661,7 @@ pub struct ResumeTableTargets<'a> {
 }
 
 impl<'a> Iterator for ResumeTableTargets<'a> {
-    type Item = Result<(u32,u32)>;
+    type Item = Result<(u32, u32)>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = usize::try_from(self.remaining).unwrap_or_else(|error| {

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1669,8 +1669,12 @@ impl<'a> BinaryReader<'a> {
                 index: self.read_var_u32()?,
                 table_index: self.read_var_u32()?,
             },
-            0x14 => Operator::CallRef,
-            0x15 => Operator::ReturnCallRef,
+            0x14 => Operator::CallRef {
+                ty: self.read_heap_type()?,
+            },
+            0x15 => Operator::ReturnCallRef {
+                ty: self.read_heap_type()?,
+            },
             0x18 => Operator::Delegate {
                 relative_depth: self.read_var_u32()?,
             },

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -295,6 +295,7 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_type(&mut self) -> Result<Type> {
         Ok(match self.read_u8()? {
             0x60 => Type::Func(self.read_func_type()?),
+            0x5f => Type::Cont(self.read_u32()?),
             x => return self.invalid_leading_byte(x, "type"),
         })
     }
@@ -937,6 +938,19 @@ impl<'a> BinaryReader<'a> {
             reader: BinaryReader::new_with_offset(&self.buffer[start..end], start),
             cnt: cnt as u32,
             default,
+        })
+    }
+
+    fn read_resume_table(&mut self) -> Result<ResumeTable<'a>> {
+        let cnt = self.read_size(MAX_WASM_RESUME_TABLE_SIZE, "resume_table")?;
+        let start = self.position;
+        for _ in 0..(cnt*2) {
+            self.read_var_u32()?;
+        }
+        let end = self.position;
+        Ok(ResumeTable {
+            reader: BinaryReader::new_with_offset(&self.buffer[start..end], start),
+            cnt: cnt as u32,
         })
     }
 
@@ -1952,6 +1966,27 @@ impl<'a> BinaryReader<'a> {
             0xfd => self.read_0xfd_operator()?,
             0xfe => self.read_0xfe_operator()?,
 
+            // Typed continuations operators.
+            // TODO(dhil) fixme: merge into the above list.
+            0xe0 => Operator::ContNew {
+                type_index: self.read_var_u32()?,
+            },
+            0xe1 => Operator::ContBind {
+                type_index: self.read_var_u32()?,
+            },
+            0xe2 => Operator::Suspend {
+                tag_index: self.read_var_u32()?,
+            },
+            0xe3 => Operator::Resume {
+                table: self.read_resume_table()?,
+            },
+            0xe4 => Operator::ResumeThrow {
+                tag_index: self.read_var_u32()?,
+            },
+            0xe5 => Operator::Barrier {
+                ty: self.read_block_type()?,
+            },
+
             _ => {
                 return Err(BinaryReaderError::new(
                     format!("illegal opcode: 0x{:x}", code),
@@ -2564,6 +2599,98 @@ impl fmt::Debug for BrTable<'_> {
         let mut f = f.debug_struct("BrTable");
         f.field("count", &self.cnt);
         f.field("default", &self.default);
+        match self.targets().collect::<Result<Vec<_>>>() {
+            Ok(targets) => {
+                f.field("targets", &targets);
+            }
+            Err(_) => {
+                f.field("reader", &self.reader);
+            }
+        }
+        f.finish()
+    }
+}
+
+// Resume table
+impl<'a> ResumeTable<'a> {
+    /// Returns the number of `resume` entries.
+    pub fn len(&self) -> u32 {
+        self.cnt
+    }
+
+    /// Returns whether `ResumeTable` doesn't have any entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the list of targets that this `resume` instruction will be
+    /// jumping to.
+    ///
+    /// This method will return an iterator which parses each target
+    /// of this `resume`. The returned iterator will yield
+    /// `self.len()` elements.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let buf = [0x0e, 0x02, 0x01, 0x02, 0x00];
+    /// let mut reader = wasmparser::BinaryReader::new(&buf);
+    /// let op = reader.read_operator().unwrap();
+    /// if let wasmparser::Operator::Resume { table } = op {
+    ///     let targets = table.targets().collect::<Result<Vec<_>, _>>().unwrap();
+    ///     assert_eq!(targets, [1, 2]);
+    /// }
+    /// ```
+    pub fn targets(&self) -> ResumeTableTargets {
+        ResumeTableTargets {
+            reader: self.reader.clone(),
+            remaining: self.cnt,
+        }
+    }
+}
+
+/// An iterator over the targets of a [`ResumeTable`].
+///
+/// # Note
+///
+/// This iterator parses each target of the underlying `resume`.  The
+/// iterator will yield exactly as many targets as the `resume` has.
+pub struct ResumeTableTargets<'a> {
+    reader: crate::BinaryReader<'a>,
+    remaining: u32,
+}
+
+impl<'a> Iterator for ResumeTableTargets<'a> {
+    type Item = Result<(u32,u32)>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = usize::try_from(self.remaining).unwrap_or_else(|error| {
+            panic!("could not convert remaining `u32` into `usize`: {}", error)
+        });
+        (remaining, Some(remaining))
+    }
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            if !self.reader.eof() {
+                return Some(Err(BinaryReaderError::new(
+                    "trailing data in resume",
+                    self.reader.original_position(),
+                )));
+            }
+            return None;
+        }
+        self.remaining -= 1;
+        let tag = self.reader.read_var_u32().ok()?;
+        let label = self.reader.read_var_u32().ok()?;
+        Some(Ok((tag, label)))
+    }
+}
+
+impl fmt::Debug for ResumeTable<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_struct("ResumeTable");
+        f.field("count", &self.cnt);
         match self.targets().collect::<Result<Vec<_>>>() {
             Ok(targets) => {
                 f.field("targets", &targets);

--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -34,6 +34,7 @@ pub const MAX_WASM_TABLES: usize = 100;
 pub const MAX_WASM_MEMORIES: usize = 100;
 pub const MAX_WASM_TAGS: usize = 1_000_000;
 pub const MAX_WASM_BR_TABLE_SIZE: usize = MAX_WASM_FUNCTION_SIZE;
+pub const MAX_WASM_RESUME_TABLE_SIZE: usize = MAX_WASM_FUNCTION_SIZE;
 
 // Component-related limits
 pub const MAX_WASM_MODULE_SIZE: usize = 1024 * 1024 * 1024; //= 1 GiB

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -14,8 +14,8 @@
  */
 
 use crate::{
-    BinaryReader, BinaryReaderError, ConstExpr, ExternalKind, Result, SectionIteratorLimited,
-    SectionReader, SectionWithLimitedItems, RefType, FUNC_REF,
+    BinaryReader, BinaryReaderError, ConstExpr, ExternalKind, RefType, Result,
+    SectionIteratorLimited, SectionReader, SectionWithLimitedItems, FUNC_REF,
 };
 use std::ops::Range;
 

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -56,6 +56,13 @@ pub struct BrTable<'a> {
     pub(crate) default: u32,
 }
 
+/// A resume entries representation.
+#[derive(Clone)]
+pub struct ResumeTable<'a> {
+    pub(crate) reader: crate::BinaryReader<'a>,
+    pub(crate) cnt: u32,
+}
+
 /// An IEEE binary32 immediate floating point value, represented as a u32
 /// containing the bit pattern.
 ///
@@ -1014,6 +1021,35 @@ pub enum Operator<'a> {
     F32x4RelaxedMax,
     F64x2RelaxedMin,
     F64x2RelaxedMax,
+
+    // Typed continuations instructions.
+    // TODO(dhil): merge into the above list.
+    ContNew {
+        type_index: u32,
+    },
+    ContBind {
+        type_index: u32,
+    },
+    Suspend {
+        tag_index: u32,
+    },
+    Resume {
+        table: ResumeTable<'a>,
+    },
+    ResumeThrow {
+        tag_index: u32,
+    },
+    Barrier {
+        ty: BlockType,
+    }
+}
+
+/// A handler case.
+#[derive(Clone, Copy, Debug)]
+#[allow(missing_docs)]
+pub struct HandleCase {
+    pub tag_index: u32,
+    pub label_index: u32,
 }
 
 /// A reader for a core WebAssembly function's operators.

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -153,7 +153,7 @@ pub enum Operator<'a> {
     Call {
         function_index: u32,
     },
-    CallRef,
+    CallRef { ty: HeapType },
     CallIndirect {
         index: u32,
         table_index: u32,
@@ -162,7 +162,7 @@ pub enum Operator<'a> {
     ReturnCall {
         function_index: u32,
     },
-    ReturnCallRef,
+    ReturnCallRef { ty: HeapType },
     ReturnCallIndirect {
         index: u32,
         table_index: u32,

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -66,13 +66,13 @@ pub enum HeapType {
 
 /// funcref, in both reference types and function references, represented
 /// using the general ref syntax
-pub(crate) const FUNC_REF: RefType = RefType {
+pub const FUNC_REF: RefType = RefType {
     nullable: true,
     heap_type: HeapType::Func,
 };
 /// externref, in both reference types and function references, represented
 /// using the general ref syntax
-pub(crate) const EXTERN_REF: RefType = RefType {
+pub const EXTERN_REF: RefType = RefType {
     nullable: true,
     heap_type: HeapType::Extern,
 };

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -82,6 +82,8 @@ pub const EXTERN_REF: RefType = RefType {
 pub enum Type {
     /// The type is for a function.
     Func(FuncType),
+    /// The type is for a continuation.
+    Cont(u32),
 }
 
 /// Represents a type of a function in a WebAssembly module.
@@ -159,6 +161,8 @@ pub struct GlobalType {
 pub enum TagKind {
     /// The tag is an exception type.
     Exception,
+    /// The tag is an control type.
+    Control,
 }
 
 /// A tag's type.

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -209,12 +209,14 @@ pub trait WasmModuleResources {
     /// Returns the global variable at given index.
     fn global_at(&self, at: u32) -> Option<GlobalType>;
     /// Returns the `FuncType` associated with the given type index.
-    fn func_type_at(&self, type_idx: u32) -> Option<&Self::FuncType>;
+    fn func_type_at(&self, at: u32) -> Option<&Self::FuncType>;
     /// Returns the type index associated with the given function
     /// index. type_of_function = func_type_at(type_index_of_function)
     fn type_index_of_function(&self, func_idx: u32) -> Option<u32>;
     /// Returns the `FuncType` associated with the given function index.
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType>;
+    /// Return the `Cont` type associated with the given type index.
+    fn cont_type_at(&self, at: u32) -> Option<u32>;
     /// Returns the element type at the given index.
     fn element_type_at(&self, at: u32) -> Option<RefType>;
     /// Under the function references proposal, returns whether t1 <=
@@ -263,6 +265,9 @@ where
     }
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
+    }
+    fn cont_type_at(&self, at: u32) -> Option<u32> {
+        T::cont_type_at(self, at)
     }
     fn check_value_type(
         &self,
@@ -322,6 +327,10 @@ where
 
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
+    }
+
+    fn cont_type_at(&self, at: u32) -> Option<u32> {
+        T::cont_type_at(self, at)
     }
 
     fn check_value_type(

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -241,6 +241,8 @@ pub struct WasmFeatures {
     pub component_model: bool,
     /// The WebAssembly typed function references proposal
     pub function_references: bool,
+    /// The typed continuations proposals
+    pub typed_continuations: bool,
 }
 
 impl WasmFeatures {
@@ -295,6 +297,7 @@ impl Default for WasmFeatures {
             component_model: false,
             deterministic_only: cfg!(feature = "deterministic"),
             function_references: false,
+            typed_continuations: false,
 
             // on-by-default features
             mutable_global: true,

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -6,9 +6,10 @@ use super::{
     types::{EntityType, Type, TypeId, TypeList},
 };
 use crate::{
-    limits::*, BinaryReaderError, ConstExpr, Data, DataKind, FUNC_REF, Element, ElementItem, ElementKind,
-    ExternalKind, FuncType, Global, GlobalType, HeapType, MemoryType, Operator, RefType, Result, TableType, TagType,
-    TypeRef, ValType, WasmFeatures, WasmFuncType, WasmModuleResources
+    limits::*, BinaryReaderError, ConstExpr, Data, DataKind, Element, ElementItem, ElementKind,
+    ExternalKind, FuncType, Global, GlobalType, HeapType, MemoryType, Operator, RefType, Result,
+    TableType, TagType, TypeRef, ValType, WasmFeatures, WasmFuncType, WasmModuleResources,
+    FUNC_REF,
 };
 use indexmap::IndexMap;
 use std::{collections::HashSet, sync::Arc};
@@ -371,6 +372,7 @@ pub(crate) struct Module {
     pub element_types: Vec<RefType>,
     pub data_count: Option<u32>,
     // Stores indexes into `types`.
+    pub continuations: Vec<u32>,
     pub functions: Vec<u32>,
     pub tags: Vec<TypeId>,
     pub function_references: HashSet<u32>,
@@ -402,6 +404,9 @@ impl Module {
                     ));
                 }
                 Type::Func(t)
+            }
+            crate::Type::Cont(_) => {
+                todo!("Implement add_type for Cont")
             }
         };
 
@@ -968,6 +973,7 @@ impl Default for Module {
             globals: Default::default(),
             element_types: Default::default(),
             data_count: Default::default(),
+            continuations: Default::default(),
             functions: Default::default(),
             tags: Default::default(),
             function_references: Default::default(),
@@ -1022,6 +1028,10 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
 
     fn type_of_function(&self, at: u32) -> Option<&Self::FuncType> {
         self.func_type_at(self.type_index_of_function(at)?)
+    }
+
+    fn cont_type_at(&self, at: u32) -> Option<u32> {
+        todo!("Implement cont_type_at")
     }
 
     fn check_value_type(&self, t: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
@@ -1096,6 +1106,10 @@ impl WasmModuleResources for ValidatorResources {
     fn check_value_type(&self, t: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
         self.0
             .check_value_type(t, features, self.0.snapshot.as_ref().unwrap(), offset)
+    }
+
+    fn cont_type_at(&self, at: u32) -> Option<u32> {
+        todo!("Implement cont_type_at")
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2237,6 +2237,114 @@ impl OperatorValidator {
                 self.pop_operand(Some(ValType::Ref(ty)), resources)?;
                 self.pop_operand(Some(ValType::I32), resources)?;
             }
+
+            // Typed continuations operators.
+            // TODO(dhil) fixme: merge into the above list.
+            Operator::ContNew { type_index } => {
+                let ct = cont_type_at(resources, type_index)?;
+                let ft = match self.pop_ref(resources)? {
+                    RefType { heap_type: HeapType::Index(type_index), .. } => cont_type_at(resources, type_index)?,
+                    _ => panic!("mismatch error") // TODO(dhil): tidy up
+                };
+                for (ty1, ty2) in ft.inputs().rev().zip(ct.inputs().rev()) {
+                    if !resources.matches(ty1, ty2) {
+                        panic!("type error") // TODO(dhil): tidy up
+                    }
+                }
+
+                for (ty1, ty2) in ft.outputs().zip(ct.outputs()) {
+                    if !resources.matches(ty1, ty2) {
+                        panic!("type error") // TODO(dhil): tidy up
+                    }
+                }
+
+                self.push_operand(ValType::Ref(RefType { heap_type: HeapType::Index(type_index), nullable: true }), resources)?;
+            }
+            Operator::ContBind { type_index } => {
+                let ft2 = cont_type_at(resources, type_index)?;
+                let ft1 = match self.pop_ref(resources)? {
+                    RefType { heap_type: HeapType::Index(type_index), .. } => cont_type_at(resources, type_index)?,
+                    _ => panic!("error computing tp1len"),
+                };
+
+                if ft2.inputs().len() < ft1.inputs().len() {
+                    panic!("mismatch error") // TODO(dhil): tidy up
+                }
+
+                let mut ft2ins = ft2.inputs().rev();
+                let mut ft1ins = ft1.inputs().rev();
+
+                loop {
+                    match ft2ins.next() {
+                        None => break,
+                        Some(ty2) => {
+                            let ty1 = if let Some(ty1) = ft1ins.next() { ty1 } else { panic!("error") /* TODO(dhil): tidy up */ };
+                            if !resources.matches(ty1, ty2) {
+                                panic!("Type error") // TODO(dhil): tidy up
+                            }
+                        }
+                    }
+                }
+
+                for ty in ft1ins {
+                    self.pop_operand(Some(ty), resources)?;
+                }
+
+
+                let ft2outs = ft2.outputs().rev();
+                let ft1outs = ft1.outputs().rev();
+                if ft1outs.len() != ft2outs.len() {
+                    panic!("Mismatch error") // TODO(dhil): tidy up
+                }
+                for (ty1, ty2) in ft1outs.zip(ft2outs) {
+                    if !resources.matches(ty1, ty2) {
+                        panic!("Type error") // TODO(dhil): tidy up
+                    }
+                }
+                self.push_operand(ValType::Ref(RefType { heap_type: HeapType::Index(type_index), nullable: true }), resources)?;
+            }
+            Operator::Suspend { tag_index } => {
+                let ft = tag_at(resources, tag_index)?;
+                for ty in ft.inputs().rev() {
+                    self.pop_operand(Some(ty), resources)?;
+                }
+                for ty in ft.outputs() {
+                    self.push_operand(ty, resources)?;
+                }
+            }
+            Operator::Resume { table: _ } => {
+                // TODO(dhil): check that the table is well-formed.
+                let ct = match self.pop_ref(resources)? {
+                    RefType { heap_type: HeapType::Index(type_index), .. } => cont_type_at(resources, type_index)?,
+                    _ => panic!("mismatch error") // TODO(dhil): tidy up
+                };
+
+                for ty in ct.inputs().rev() {
+                    self.pop_operand(Some(ty), resources)?;
+                }
+
+                for ty in ct.outputs() {
+                    self.push_operand(ty, resources)?;
+                }
+            }
+            Operator::ResumeThrow { tag_index } => {
+                let ct = match self.pop_ref(resources)? {
+                    RefType { heap_type: HeapType::Index(type_index), .. } => cont_type_at(resources, type_index)?,
+                    _ => panic!("mismatch error") // TODO(dhil): tidy up
+                };
+                let ft = tag_at(resources, tag_index)?;
+
+                for ty in ft.inputs().rev() {
+                    self.pop_operand(Some(ty), resources)?;
+                }
+
+                for ty in ct.outputs() {
+                    self.push_operand(ty, resources)?;
+                }
+            }
+            Operator::Barrier { ty: _ } => {
+                todo!("Implement Barrier")
+            }
         }
         Ok(())
     }
@@ -2253,6 +2361,16 @@ fn func_type_at<T: WasmModuleResources>(
     resources: &T,
     at: u32,
 ) -> OperatorValidatorResult<&T::FuncType> {
+    resources
+        .func_type_at(at)
+        .ok_or_else(|| OperatorValidatorError::new("unknown type: type index out of bounds"))
+}
+
+fn cont_type_at<T: WasmModuleResources>(
+    resources: &T,
+    at: u32,
+) -> OperatorValidatorResult<&T::FuncType> {
+    // TODO(dhil): use `u = cont_type_at(at);` to as input to func_type_at(u)
     resources
         .func_type_at(at)
         .ok_or_else(|| OperatorValidatorError::new("unknown type: type index out of bounds"))
@@ -2368,6 +2486,6 @@ fn ty_to_str(ty: ValType) -> String {
                     HeapType::Bot => "bot".into(),
                 }
             ),
-        },
+        }
     }
 }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2370,9 +2370,9 @@ fn cont_type_at<T: WasmModuleResources>(
     resources: &T,
     at: u32,
 ) -> OperatorValidatorResult<&T::FuncType> {
-    // TODO(dhil): use `u = cont_type_at(at);` to as input to func_type_at(u)
+    let u = resources.cont_type_at(at).ok_or_else(|| OperatorValidatorError::new("unknown continuation type: type index out of bounds"));
     resources
-        .func_type_at(at)
+        .func_type_at(u?)
         .ok_or_else(|| OperatorValidatorError::new("unknown type: type index out of bounds"))
 }
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -3,8 +3,8 @@
 use super::{component::ComponentState, core::Module};
 use crate::{
     ComponentExport, ComponentExternalKind, ComponentImport, ComponentTypeRef, Export,
-    ExternalKind, FuncType, GlobalType, Import, MemoryType, PrimitiveValType, TableType, TypeRef,
-    ValType, RefType,
+    ExternalKind, FuncType, GlobalType, Import, MemoryType, PrimitiveValType, RefType, TableType,
+    TypeRef, ValType,
 };
 use indexmap::{IndexMap, IndexSet};
 use std::{

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1030,7 +1030,10 @@ impl Printer {
                 self.result.push_str("call ");
                 self.print_idx(&state.core.func_names, *function_index)?;
             }
-            CallRef => self.result.push_str("call_ref"),
+            CallRef { ty } => {
+                self.result.push_str("call_ref ");
+                self.print_heaptype(*ty)?;
+            }
             CallIndirect {
                 table_index,
                 index,
@@ -1047,7 +1050,10 @@ impl Printer {
                 self.result.push_str("return_call ");
                 self.print_idx(&state.core.func_names, *function_index)?;
             }
-            ReturnCallRef => self.result.push_str("return_call_ref"),
+            ReturnCallRef { ty } => {
+                self.result.push_str("return_call_ref");
+                self.print_heaptype(*ty)?;
+            }
             ReturnCallIndirect { table_index, index } => {
                 self.result.push_str("return_call_indirect");
                 if *table_index != 0 {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -546,6 +546,7 @@ impl Printer {
                 self.end_group();
                 ty
             }
+            wasmparser::Type::Cont(ty) => todo!(),
         };
         self.end_group(); // `type` itself
         state.core.types.push(Some(ty));
@@ -1872,6 +1873,13 @@ impl Printer {
             F32x4RelaxedMax => self.result.push_str("f32x4.relaxed_max"),
             F64x2RelaxedMin => self.result.push_str("f64x2.relaxed_min"),
             F64x2RelaxedMax => self.result.push_str("f64x2.relaxed_max"),
+
+            ContNew { .. }
+            | ContBind { .. }
+            | Suspend { .. }
+            | Resume { .. }
+            | ResumeThrow { .. }
+            | Barrier { .. } => todo!(),
         }
         Ok(())
     }


### PR DESCRIPTION
This patch merges in the latest changes to `func-ref-2`. In addition,
it also adds stubs in `wasm-mutate`, `wasm-smith`, and `wasm-shrink`
to make `cargo check` succeed.