### PR TITLE
Typed continuations fixups

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -817,22 +817,16 @@ impl<'a> BinaryReader<'a> {
 
     pub(crate) fn read_tag_type(&mut self) -> Result<TagType> {
         let attribute = self.read_u8()?;
-        match attribute {
-            0 => Ok(TagType {
-                kind: TagKind::Exception,
-                func_type_idx: self.read_var_u32()?,
-            }),
-            1 => Ok(TagType {
-                kind: TagKind::Control,
-                func_type_idx: self.read_var_u32()?,
-            }),
-            _ => {
-                return Err(BinaryReaderError::new(
-                    "invalid tag attributes",
-                    self.original_position() - 1,
-                ));
-            }
+        if attribute != 0 {
+            return Err(BinaryReaderError::new(
+                "invalid tag attributes",
+                self.original_position() - 1,
+            ));
         }
+        Ok(TagType {
+            kind: TagKind::Exception,
+            func_type_idx: self.read_var_u32()?,
+        })
     }
 
     pub(crate) fn read_global_type(&mut self) -> Result<GlobalType> {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -161,8 +161,6 @@ pub struct GlobalType {
 pub enum TagKind {
     /// The tag is an exception type.
     Exception,
-    /// The tag is an control type.
-    Control,
 }
 
 /// A tag's type.

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1293,8 +1293,8 @@ impl<'a> Parse<'a> for ResumeTableIndices<'a> {
         let mut targets = vec![];
         while parser.peek2::<kw::tag>() {
             parser.parens(|p| {
-                parser.parse::<kw::tag>()?;
-                targets.push(parser.parse()?);
+                p.parse::<kw::tag>()?;
+                targets.push(p.parse()?);
                 Ok(())
             })?;
         }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -341,7 +341,8 @@ impl TestState {
             | WastDirective::AssertReturn { .. }
             | WastDirective::AssertExhaustion { .. }
             | WastDirective::AssertUnlinkable { .. }
-            | WastDirective::AssertException { .. } => {}
+            | WastDirective::AssertException { .. }
+            | WastDirective::AssertSuspension { .. } => {}
         }
         Ok(())
     }
@@ -437,6 +438,7 @@ impl TestState {
             sign_extension: true,
             mutable_global: true,
             function_references: true,
+            typed_continuations: true,
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {


### PR DESCRIPTION
This patch reconciles exception and control tags again, as they are now the same upstream.

Also, I noticed that the testrunner didn't build due to the addition of `AssertSuspension` -- that's fixed now. Although, it seems there has been a regression as the subtyping relation (`matches`) seem to fail in `CallRef` and `ReturnCallRef` now.