### PR TITLE
Revert "Backport type annotations on `CallRef` and `ReturnCallRef`.

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -322,9 +322,9 @@ pub enum Instruction<'a> {
     BrOnNonNull(u32),
     Return,
     Call(u32),
-    CallRef(ValType),
+    CallRef,
     CallIndirect { ty: u32, table: u32 },
-    ReturnCallRef(ValType),
+    ReturnCallRef,
     Throw(u32),
     Rethrow(u32),
 
@@ -916,19 +916,13 @@ impl Encode for Instruction<'_> {
                 sink.push(0x10);
                 f.encode(sink);
             }
-            Instruction::CallRef(ty) => {
-                sink.push(0x14);
-                ty.encode(sink);
-            }
+            Instruction::CallRef => sink.push(0x14),
             Instruction::CallIndirect { ty, table } => {
                 sink.push(0x11);
                 ty.encode(sink);
                 table.encode(sink);
             }
-            Instruction::ReturnCallRef(ty) => {
-                sink.push(0x15);
-                ty.encode(sink);
-            }
+            Instruction::ReturnCallRef => sink.push(0x15),
             Instruction::Delegate(l) => {
                 sink.push(0x18);
                 l.encode(sink);

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -325,7 +325,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
 
         O::Return => I::Return,
         O::Call { function_index } => I::Call(t.remap(Item::Function, *function_index)?),
-        O::CallRef { ty } => I::CallRef(t.translate_heapty(ty)?),
+        O::CallRef => I::CallRef,
         O::CallIndirect {
             index,
             table_index,
@@ -334,7 +334,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
             ty: t.remap(Item::Type, *index)?,
             table: t.remap(Item::Table, *table_index)?,
         },
-        O::ReturnCallRef { ty } => I::ReturnCallRef(t.translate_heapty(ty)?),
+        O::ReturnCallRef => I::ReturnCallRef,
         O::Delegate { relative_depth } => I::Delegate(*relative_depth),
         O::CatchAll => I::CatchAll,
         O::Drop => I::Drop,

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1683,12 +1683,8 @@ impl<'a> BinaryReader<'a> {
                 index: self.read_var_u32()?,
                 table_index: self.read_var_u32()?,
             },
-            0x14 => Operator::CallRef {
-                ty: self.read_heap_type()?,
-            },
-            0x15 => Operator::ReturnCallRef {
-                ty: self.read_heap_type()?,
-            },
+            0x14 => Operator::CallRef,
+            0x15 => Operator::ReturnCallRef,
             0x18 => Operator::Delegate {
                 relative_depth: self.read_var_u32()?,
             },

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -160,7 +160,7 @@ pub enum Operator<'a> {
     Call {
         function_index: u32,
     },
-    CallRef { ty: HeapType },
+    CallRef,
     CallIndirect {
         index: u32,
         table_index: u32,
@@ -169,7 +169,7 @@ pub enum Operator<'a> {
     ReturnCall {
         function_index: u32,
     },
-    ReturnCallRef { ty: HeapType },
+    ReturnCallRef,
     ReturnCallIndirect {
         index: u32,
         table_index: u32,

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -876,25 +876,25 @@ impl OperatorValidator {
                 }
                 self.check_call_indirect(index, table_index, resources)?
             }
-            Operator::CallRef { ty } => {
+            Operator::CallRef => {
                 self.check_function_references_enabled()?;
                 let rt = self.pop_ref(resources)?;
-                let expected = RefType {
-                    nullable: true,
-                    heap_type: ty,
-                };
-                if !resources.matches(ValType::Ref(rt), ValType::Ref(expected)) {
-                    bail_op_err!(
-                        "type mismatch: funcref on stack does not match specified type",
-                    );
-                }
                 match rt.heap_type {
-                    HeapType::Index(type_index) => self.check_call(type_index, resources)?,
+                    HeapType::Index(type_index) =>
+                    {
+                        let ft = func_type_at(resources, type_index)?;
+                        for ty in ft.inputs().rev() {
+                            self.pop_operand(Some(ty), resources)?;
+                        }
+                        for ty in ft.outputs() {
+                            self.push_operand(ty, resources)?;
+                        }
+                    },
                     HeapType::Bot => (),
                     _ => bail_op_err!("type mismatch: instruction requires function reference type but stack has {}", ty_to_str(ValType::Ref(rt)))
                 }
             }
-            Operator::ReturnCallRef { ty }=> {
+            Operator::ReturnCallRef => {
                 self.check_function_references_enabled()?;
                 if !self.features.tail_call {
                     return Err(OperatorValidatorError::new(
@@ -902,17 +902,16 @@ impl OperatorValidator {
                     ));
                 }
                 let rt = self.pop_ref(resources)?;
-                let expected = RefType {
-                    nullable: true,
-                    heap_type: ty,
-                };
-                if !resources.matches(ValType::Ref(rt), ValType::Ref(expected)) {
-                    bail_op_err!(
-                        "type mismatch: funcref on stack does not match specified type",
-                    );
-                }
                 match rt.heap_type {
-                    HeapType::Index(type_index) => self.check_call(type_index, resources)?,
+                    HeapType::Index(type_index) => {
+                        let ft = func_type_at(resources, type_index)?;
+                        for ty in ft.inputs().rev() {
+                            self.pop_operand(Some(ty), resources)?;
+                        }
+                        for ty in ft.outputs() {
+                            self.push_operand(ty, resources)?;
+                        }
+                    },
                     HeapType::Bot => (),
                     _ => bail_op_err!("type mismatch: instruction requires function reference type but stack has {}", ty_to_str(ValType::Ref(rt)))
                 }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1034,10 +1034,7 @@ impl Printer {
                 self.result.push_str("call ");
                 self.print_idx(&state.core.func_names, *function_index)?;
             }
-            CallRef { ty } => {
-                self.result.push_str("call_ref ");
-                self.print_heaptype(*ty)?;
-            }
+            CallRef => self.result.push_str("call_ref"),
             CallIndirect {
                 table_index,
                 index,
@@ -1054,10 +1051,7 @@ impl Printer {
                 self.result.push_str("return_call ");
                 self.print_idx(&state.core.func_names, *function_index)?;
             }
-            ReturnCallRef { ty } => {
-                self.result.push_str("return_call_ref");
-                self.print_heaptype(*ty)?;
-            }
+            ReturnCallRef => self.result.push_str("return_call_ref"),
             ReturnCallIndirect { table_index, index } => {
                 self.result.push_str("return_call_indirect");
                 if *table_index != 0 {


### PR DESCRIPTION
This reverts commit 41c03a96fb543385d4750a0f58fe6a29aa49010a.