### PR TITLE
Remove `ValType::Bot`

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -201,7 +201,6 @@ impl<'a> TypeEncoder<'a> {
             wasmparser::ValType::F64 => ValType::F64,
             wasmparser::ValType::V128 => ValType::V128,
             wasmparser::ValType::Ref(ty) => Self::ref_type(ty),
-            wasmparser::ValType::Bot => unimplemented!(),
         }
     }
 

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -35,7 +35,6 @@ impl From<wasmparser::ValType> for PrimitiveTypeInfo {
             wasmparser::ValType::F64 => PrimitiveTypeInfo::F64,
             wasmparser::ValType::V128 => PrimitiveTypeInfo::V128,
             wasmparser::ValType::Ref(t) => t.into(),
-            wasmparser::ValType::Bot => unreachable!(),
         }
     }
 }
@@ -79,7 +78,6 @@ pub fn map_type(tpe: wasmparser::ValType) -> Result<ValType> {
         wasmparser::ValType::F64 => Ok(ValType::F64),
         wasmparser::ValType::V128 => Ok(ValType::V128),
         wasmparser::ValType::Ref(t) => map_ref_type(t),
-        wasmparser::ValType::Bot => unimplemented!(),
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -127,7 +127,6 @@ impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
                 T::Ref(wasmparser::FUNC_REF) => CE::ref_null(wasm_encoder::ValType::FuncRef),
                 T::Ref(wasmparser::EXTERN_REF) => CE::ref_null(wasm_encoder::ValType::ExternRef),
                 T::Ref(_) => unimplemented!(),
-                T::Bot => unreachable!(),
             }
         } else {
             // FIXME: implement non-reducing mutations for constant expressions.

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1572,7 +1572,6 @@ fn convert_type(parsed_type: wasmparser::ValType) -> ValType {
         F64 => ValType::F64,
         V128 => ValType::V128,
         Ref(ty) => convert_reftype(ty),
-        Bot => unreachable!(),
     }
 }
 

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -35,8 +35,6 @@ pub enum ValType {
     /// which now provides FuncRef and ExternRef as sugar for the generic ref
     /// construct.
     Ref(RefType),
-    /// Special bottom type.
-    Bot,
 }
 
 /// A reference type. When the function references feature is disabled, this

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -242,7 +242,7 @@ impl WasmFeatures {
     /// types. Use module.check_value_type.
     pub(crate) fn check_value_type(&self, ty: ValType) -> Result<(), &'static str> {
         match ty {
-            ValType::Bot | ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => Ok(()),
+            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => Ok(()),
             ValType::Ref(r) => {
                 if self.reference_types {
                     if !self.function_references {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -860,7 +860,6 @@ impl Module {
 
         match (ty1, ty2) {
             (ValType::Ref(rt1), ValType::Ref(rt2)) => matches_ref(rt1, rt2, types),
-            (ValType::Bot, _) => true,
             (_, _) => ty1 == ty2,
         }
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -452,7 +452,7 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
 
     fn pop_ref(&mut self, offset: usize) -> Result<RefType> {
         match self.pop_operand(offset, None)? {
-            None | Some(ValType::Bot) => Ok(RefType {
+            None => Ok(RefType {
                 nullable: false,
                 heap_type: HeapType::Bot,
             }),
@@ -982,7 +982,6 @@ fn ty_to_str(ty: ValType) -> &'static str {
             nullable: false,
             heap_type: HeapType::Bot,
         }) => "(ref bot)",
-        ValType::Bot => "bot",
     }
 }
 

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -651,7 +651,6 @@ impl Printer {
             ValType::F64 => self.result.push_str("f64"),
             ValType::V128 => self.result.push_str("v128"),
             ValType::Ref(rt) => self.print_reftype(rt)?,
-            ValType::Bot => self.result.push_str("bot"),
         }
         Ok(())
     }


### PR DESCRIPTION
This patch removes the `Bot` constructor from the `ValType`.