### PR TITLE
Typed continuations: allow tags with results; allow partial cont.bind

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -105,6 +105,17 @@ impl ValType {
     pub fn is_reference_type(&self) -> bool {
         matches!(self, ValType::Ref(_))
     }
+    /// Whether the type is defaultable according to function references
+    /// spec. This amounts to whether it's a non-nullable ref
+    pub fn is_defaultable(&self) -> bool {
+        !matches!(
+            self,
+            ValType::Ref(RefType {
+                nullable: false,
+                ..
+            })
+        )
+    }
 }
 
 /// Represents a type in a WebAssembly module.

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::ops::Range;
 
 /// Represents the types of values in a WebAssembly module.
@@ -66,6 +66,12 @@ impl TryFrom<u32> for HeapType {
     type Error = <u16 as TryFrom<u32>>::Error;
     fn try_from(x: u32) -> Result<HeapType, Self::Error> {
         Ok(HeapType::TypedFunc(PackedIndex(x.try_into()?)))
+    }
+}
+impl Display for PackedIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let i = self.0;
+        write!(f, "{}", i)
     }
 }
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -897,7 +897,7 @@ impl Module {
             ));
         }
         let ty = self.func_type_at(ty.func_type_idx, types, offset)?;
-        if !ty.results().is_empty() {
+        if !ty.results().is_empty() && !features.typed_continuations {
             return Err(BinaryReaderError::new(
                 "invalid exception type: non-empty tag result type",
                 offset,

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -441,7 +441,7 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
             if self.operands.len() == control.height {
                 let desc = match expected {
                     Some(ty) => ty_to_str(ty),
-                    None => "a type",
+                    None => "a type".into(),
                 };
                 bail!(
                     offset,
@@ -1018,7 +1018,10 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
 
             // label_types(offset, block.0, block.1) := ts1''* (ref null? (cont $ft))
             if tagtype.inputs().len() != self.label_types(offset, block.0, block.1)?.len() - 1 {
-                panic!("type mismatch between label and tag types") // TODO(dhil): tidy up
+                bail!(
+                    offset,
+                    "type mismatch between label type and tag type length"
+                ) // TODO(dhil): tidy up
             }
             let labeltys = self
                 .label_types(offset, block.0, block.1)?
@@ -1058,39 +1061,39 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
     }
 }
 
-fn ty_to_str(ty: ValType) -> &'static str {
+fn ty_to_str(ty: ValType) -> String {
     match ty {
-        ValType::I32 => "i32",
-        ValType::I64 => "i64",
-        ValType::F32 => "f32",
-        ValType::F64 => "f64",
-        ValType::V128 => "v128",
-        ValType::Ref(FUNC_REF) => "funcref",
-        ValType::Ref(EXTERN_REF) => "externref",
+        ValType::I32 => "i32".into(),
+        ValType::I64 => "i64".into(),
+        ValType::F32 => "f32".into(),
+        ValType::F64 => "f64".into(),
+        ValType::V128 => "v128".into(),
+        ValType::Ref(FUNC_REF) => "funcref".into(),
+        ValType::Ref(EXTERN_REF) => "externref".into(),
         ValType::Ref(RefType {
             nullable: false,
             heap_type: HeapType::Func,
-        }) => "(ref func)",
+        }) => "(ref func)".into(),
         ValType::Ref(RefType {
             nullable: false,
             heap_type: HeapType::Extern,
-        }) => "(ref extern)",
+        }) => "(ref extern)".into(),
         ValType::Ref(RefType {
             nullable: false,
-            heap_type: HeapType::TypedFunc(_),
-        }) => "(ref $type)",
+            heap_type: HeapType::TypedFunc(i),
+        }) => format!("(ref {})", i),
         ValType::Ref(RefType {
             nullable: true,
-            heap_type: HeapType::TypedFunc(_),
-        }) => "(ref null $type)",
+            heap_type: HeapType::TypedFunc(i),
+        }) => format!("(ref null {})", i),
         ValType::Ref(RefType {
             nullable: true,
             heap_type: HeapType::Bot,
-        }) => "(ref null bot)",
+        }) => "(ref null bot)".into(),
         ValType::Ref(RefType {
             nullable: false,
             heap_type: HeapType::Bot,
-        }) => "(ref bot)",
+        }) => "(ref bot)".into(),
     }
 }
 

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -3465,7 +3465,7 @@ where
                     // TODO(dhil): Tidy up
                 }
                 // Next check that prefix of ft1's domain agrees with the domain of ft2.
-                //let ft1ins1 = ft1.inputs().take(ft1.inputs().len() - ft2.inputs().len());
+                let ft1ins1 = ft1.inputs().take(ft1.inputs().len() - ft2.inputs().len());
                 let ft1ins2 = ft1.inputs().skip(ft1.inputs().len() - ft2.inputs().len());
 
                 for (ty1, ty2) in ft1ins2.zip(ft2.inputs()) {
@@ -3486,14 +3486,14 @@ where
                     }
                 }
 
-                // Check that ft1's inputs are available on the stack.
-                for ty in ft1.inputs().rev() {
+                // Check that the bound ft1 inputs are available on the stack.
+                for ty in ft1ins1.rev() {
                     self.pop_operand(offset, Some(ty))?;
                 }
 
                 // Push the continuation reference.
                 self.push_operand(ValType::Ref(RefType {
-                    nullable: rt.nullable,
+                    nullable: false,
                     heap_type: type_index
                         .try_into()
                         .expect("function reference index larger than 2^16"),

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -31,6 +31,7 @@ use std::ops::{Deref, DerefMut};
 
 pub(crate) struct OperatorValidator {
     pub(super) locals: Locals,
+    pub(super) local_inits: Vec<bool>,
 
     // This is a list of flags for wasm features which are used to gate various
     // instructions.
@@ -43,6 +44,9 @@ pub(crate) struct OperatorValidator {
     control: Vec<Frame>,
     /// The `operands` is the current type stack.
     operands: Vec<Option<ValType>>,
+    /// When local_inits is modified, the relevant index is recorded here to be
+    /// undone when control pops
+    inits: Vec<u32>,
 
     /// Offset of the `end` instruction which emptied the `control` stack, which
     /// must be the end of the function.
@@ -93,6 +97,8 @@ pub struct Frame {
     pub height: usize,
     /// Whether this frame is unreachable so far.
     pub unreachable: bool,
+    /// The number of initializations in the stack at the time of its creation
+    pub init_height: usize,
 }
 
 /// The kind of a control flow [`Frame`].
@@ -142,6 +148,8 @@ pub struct OperatorValidatorAllocations {
     br_table_tmp: Vec<Option<ValType>>,
     control: Vec<Frame>,
     operands: Vec<Option<ValType>>,
+    local_inits: Vec<bool>,
+    inits: Vec<u32>,
     locals_first: Vec<ValType>,
     locals_all: Vec<(u32, ValType)>,
 }
@@ -152,12 +160,16 @@ impl OperatorValidator {
             br_table_tmp,
             control,
             operands,
+            local_inits,
+            inits,
             locals_first,
             locals_all,
         } = allocs;
         debug_assert!(br_table_tmp.is_empty());
         debug_assert!(control.is_empty());
         debug_assert!(operands.is_empty());
+        debug_assert!(local_inits.is_empty());
+        debug_assert!(inits.is_empty());
         debug_assert!(locals_first.is_empty());
         debug_assert!(locals_all.is_empty());
         OperatorValidator {
@@ -166,6 +178,8 @@ impl OperatorValidator {
                 first: locals_first,
                 all: locals_all,
             },
+            local_inits,
+            inits,
             features: *features,
             br_table_tmp,
             operands,
@@ -195,6 +209,7 @@ impl OperatorValidator {
             block_type: BlockType::FuncType(ty),
             height: 0,
             unreachable: false,
+            init_height: 0,
         });
         let params = OperatorValidatorTemp {
             inner: &mut ret,
@@ -204,6 +219,7 @@ impl OperatorValidator {
         .inputs();
         for ty in params {
             ret.locals.define(1, ty);
+            ret.local_inits.push(true);
         }
         Ok(ret)
     }
@@ -222,6 +238,7 @@ impl OperatorValidator {
             block_type: BlockType::Type(ty),
             height: 0,
             unreachable: false,
+            init_height: 0,
         });
         ret
     }
@@ -234,19 +251,6 @@ impl OperatorValidator {
         resources: &impl WasmModuleResources,
     ) -> Result<()> {
         resources.check_value_type(ty, &self.features, offset)?;
-        // As far as i can tell, this isn't specified in the spec for function
-        // references, it's only tested and mentioned in the overview
-        match ty {
-            ValType::Ref(RefType {
-                nullable: false, ..
-            }) => {
-                return Err(BinaryReaderError::new(
-                    format!("non-defaultable local type: {}", ty_to_str(ty)),
-                    offset,
-                ))
-            }
-            _ => (),
-        }
         if count == 0 {
             return Ok(());
         }
@@ -256,6 +260,8 @@ impl OperatorValidator {
                 offset,
             ));
         }
+        self.local_inits
+            .resize(self.local_inits.len() + count as usize, ty.is_defaultable());
         Ok(())
     }
 
@@ -333,6 +339,8 @@ impl OperatorValidator {
             br_table_tmp: truncate(self.br_table_tmp),
             control: truncate(self.control),
             operands: truncate(self.operands),
+            local_inits: truncate(self.local_inits),
+            inits: truncate(self.inits),
             locals_first: truncate(self.locals.first),
             locals_all: truncate(self.locals.all),
         }
@@ -503,11 +511,13 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
         // Push a new frame which has a snapshot of the height of the current
         // operand stack.
         let height = self.operands.len();
+        let init_height = self.inits.len();
         self.control.push(Frame {
             kind,
             block_type: ty,
             height,
             unreachable: false,
+            init_height,
         });
         // All of the parameters are now also available in this control frame,
         // so we push them here in order.
@@ -530,6 +540,12 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
         };
         let ty = frame.block_type;
         let height = frame.height;
+        let init_height = frame.init_height;
+
+        // reset_locals in the spec
+        for init in self.inits.split_off(init_height) {
+            self.local_inits[init as usize] = false;
+        }
 
         // Pop all the result types, in reverse order, from the operand stack.
         // These types will, possibly, be transferred to the next frame.
@@ -1197,11 +1213,13 @@ where
         }
         // Start a new frame and push `exnref` value.
         let height = self.operands.len();
+        let init_height = self.inits.len();
         self.control.push(Frame {
             kind: FrameKind::Catch,
             block_type: frame.block_type,
             height,
             unreachable: false,
+            init_height,
         });
         // Push exception argument types.
         let ty = self.tag_at(index, offset)?;
@@ -1256,11 +1274,13 @@ where
             bail!(offset, "catch_all found outside of a `try` block");
         }
         let height = self.operands.len();
+        let init_height = self.inits.len();
         self.control.push(Frame {
             kind: FrameKind::CatchAll,
             block_type: frame.block_type,
             height,
             unreachable: false,
+            init_height,
         });
         Ok(())
     }
@@ -1444,17 +1464,28 @@ where
     }
     fn visit_local_get(&mut self, offset: usize, local_index: u32) -> Self::Output {
         let ty = self.local(offset, local_index)?;
+        if !self.local_inits[local_index as usize] {
+            bail!(offset, "uninitialized local: {}", local_index);
+        }
         self.push_operand(ty)?;
         Ok(())
     }
     fn visit_local_set(&mut self, offset: usize, local_index: u32) -> Self::Output {
         let ty = self.local(offset, local_index)?;
         self.pop_operand(offset, Some(ty))?;
+        if !self.local_inits[local_index as usize] {
+            self.local_inits[local_index as usize] = true;
+            self.inits.push(local_index);
+        }
         Ok(())
     }
     fn visit_local_tee(&mut self, offset: usize, local_index: u32) -> Self::Output {
         let ty = self.local(offset, local_index)?;
         self.pop_operand(offset, Some(ty))?;
+        if !self.local_inits[local_index as usize] {
+            self.local_inits[local_index as usize] = true;
+            self.inits.push(local_index);
+        }
         self.push_operand(ty)?;
         Ok(())
     }

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -90,6 +90,7 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
     const FEATURES: &[(&str, fn(&mut WasmFeatures) -> &mut bool)] = &[
         ("reference-types", |f| &mut f.reference_types),
         ("function-references", |f| &mut f.function_references),
+        ("typed-continuations", |f| &mut f.typed_continuations),
         ("simd", |f| &mut f.simd),
         ("threads", |f| &mut f.threads),
         ("bulk-memory", |f| &mut f.bulk_memory),


### PR DESCRIPTION
A handful more fixes to validation things.   Also cherry-picks the latest initialization changes from function references.    Fixes cont.bind to match the reference interpreter, allowing partial bind.    Fixes tags being rejected (disabling an old exception handlers check).    These fixes come from running a weird frankenstein version of cont.wast that I have on my disk.   I keep wanting to check it in and add it to the test suite, but there's always more reasons not to:
- Removing func.bind is really hard.    I "did it" using cont.bind and adding an argument..... but then there was another test with two arguments.    So I gave up and deleted that test.
- We don't support printing the new instructions.   It would probably not be hard, but seems like a waste of time at the moment.    So I just deleted that part of the test on my machine :)

If you would like to mess with wasm-tools and are worried about breaking things, let me know and I'll do the little bit of work to let me check in my funky test.

With those caveats, these changes allow my frankenstein test to completely pass, so I think it's reasonable for me to turn towards wasmtime as well now.     I'll ping you on zulip, but now I'm not working on anything.   So want me to take a lock on all of wasmtime and target this branch of wasm-tools?   (If you haven't already done that?)