### PR TITLE
Remove `HeapType::Bot` from the public API

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -285,7 +285,6 @@ impl<'a> TypeEncoder<'a> {
                 wasmparser::HeapType::Func => HeapType::Func,
                 wasmparser::HeapType::Extern => HeapType::Extern,
                 wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
-                wasmparser::HeapType::Bot => unreachable!(),
             },
         }
     }

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -88,7 +88,6 @@ pub fn map_ref_type(tpe: wasmparser::RefType) -> Result<RefType> {
             wasmparser::HeapType::Func => HeapType::Func,
             wasmparser::HeapType::Extern => HeapType::Extern,
             wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
-            wasmparser::HeapType::Bot => unreachable!(),
         },
     })
 }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -205,7 +205,6 @@ pub fn heapty(t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<HeapT
         wasmparser::HeapType::TypedFunc(i) => {
             Ok(HeapType::TypedFunc(t.remap(Item::Type, (*i).into())?))
         }
-        wasmparser::HeapType::Bot => unreachable!(),
     }
 }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1644,7 +1644,6 @@ fn convert_reftype(ty: wasmparser::RefType) -> RefType {
             wasmparser::HeapType::Func => wasm_encoder::HeapType::Func,
             wasmparser::HeapType::Extern => wasm_encoder::HeapType::Extern,
             wasmparser::HeapType::TypedFunc(i) => wasm_encoder::HeapType::TypedFunc(i.into()),
-            wasmparser::HeapType::Bot => unreachable!(),
         },
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -101,8 +101,6 @@ pub enum HeapType {
     Func,
     /// From reference types
     Extern,
-    /// Special bottom heap type
-    Bot,
 }
 
 impl ValType {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1504,9 +1504,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[test]
-    fn valtype_is_small() {
-        assert_eq!(std::mem::size_of::<ValType>(), 4);
-    }
 }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -810,7 +810,6 @@ impl Module {
                 // Just check that the index is valid
                 self.func_type_at(type_index.into(), types, offset)?;
             }
-            HeapType::Bot => (),
         }
         Ok(())
     }
@@ -860,7 +859,6 @@ impl Module {
                     self.eq_fns(n1, n2, types)
                 }
                 (HeapType::TypedFunc(_), HeapType::Func) => true,
-                (HeapType::Bot, _) => true,
                 (_, _) => ty1 == ty2,
             }
         };

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -713,7 +713,6 @@ impl Printer {
             HeapType::Func => self.result.push_str("func"),
             HeapType::Extern => self.result.push_str("extern"),
             HeapType::TypedFunc(i) => self.result.push_str(&format!("{}", u32::from(i))),
-            HeapType::Bot => self.result.push_str("bot"),
         }
         Ok(())
     }

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -424,7 +424,6 @@ impl<'a> Module<'a> {
         match ty {
             HeapType::Func | HeapType::Extern => {}
             HeapType::TypedFunc(i) => self.ty(i.into()),
-            HeapType::Bot => unreachable!(),
         }
     }
 
@@ -1012,7 +1011,6 @@ impl Encoder {
             wasmparser::HeapType::TypedFunc(idx) => {
                 wasm_encoder::HeapType::TypedFunc(self.types.remap(idx.into()).try_into().unwrap())
             }
-            wasmparser::HeapType::Bot => unimplemented!(),
         }
     }
 }


### PR DESCRIPTION
Move it as an internal implementation detail of the validator.